### PR TITLE
Update web components tutorial

### DIFF
--- a/Overview.asciidoc
+++ b/Overview.asciidoc
@@ -81,11 +81,11 @@ and keep the page state intact. The following tutorials explain how to use the R
 * <<web-components/tutorial-webcomponent-basic#,Basic Integration of a Polymer Web Component>>
 * <<web-components/tutorial-webcomponent-attributes-and-properties#,Using Attributes and Properties with a Polymer Web Component>>
 * <<web-components/tutorial-webcomponent-events#,Using Events with a Polymer Web Component>>
-* <<web-components/tutorial-webcomponents-es5#,Serving ES5 Web Components to older browsers with Polymer 2>>
 * <<web-components/tutorial-flow-webjars#,Webjars in Flow>>
 * <<web-components/tutorial-how-to-use-webjars#,How to use Webjars>>
 * <<web-components/tutorial-flow-maven-plugin#,Taking your app into production>>
-* <<web-components/tutorial-utorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
+* <<web-components/tutorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
+* <<web-components/tutorial-webcomponents-es5#,Serving ES5 Web Components to older browsers with Polymer 2>>
 
 == Creating Polymer Templates
 * <<polymer-templates/tutorial-template-basic#,Creating A Simple Component Using the Template API>>

--- a/Overview.asciidoc
+++ b/Overview.asciidoc
@@ -85,6 +85,7 @@ and keep the page state intact. The following tutorials explain how to use the R
 * <<web-components/tutorial-flow-webjars#,Webjars in Flow>>
 * <<web-components/tutorial-how-to-use-webjars#,How to use Webjars>>
 * <<web-components/tutorial-flow-maven-plugin#,Taking your app into production>>
+* <<web-components/tutorial-utorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
 
 == Creating Polymer Templates
 * <<polymer-templates/tutorial-template-basic#,Creating A Simple Component Using the Template API>>

--- a/web-components/tutorial-flow-maven-plugin.asciidoc
+++ b/web-components/tutorial-flow-maven-plugin.asciidoc
@@ -1,18 +1,27 @@
 ---
 title: Taking your app into production
-order: 7
+order: 6
 layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
 = Taking your app into production
 
-As mentioned in <<tutorial-webcomponents-es5#,Serving ES5 Web Components to older browsers with Polymer 2>> 
-tutorial transpilation to ECMAScript 5 is required to use an application with browsers that don't support ES6.
+According to the native custom element specification, ECMAScript 6 is required
+to define webcomponents. But when deploying an application to IE11 and Safari 9,
+ you need to transpile the files to ECMAScript 5 (ES5 for short), since those
+browsers don't support ECMAScript 6.
+
+[TIP]
+Transpilation in current context is converting ES6 JavaScript code to ES5 that is performed for older browsers be able to run it.
+
 You may also want to optimize web files (reduce a number of files and optimize their content) via bundling.
 In this case we provide `flow-maven-plugin` which sets up the project for the production mode.
-It simplifies the steps described in <<tutorial-webcomponents-es5#,Serving ES5 Web Components to older browsers with Polymer 2>> 
-tutorial.
+
+[NOTE]
+The plugin simplifies the steps described in <<tutorial-webcomponents-es5#,Serving ES5 Web Components to older browsers with Polymer 2>> 
+tutorial which should be considered as a deprecated way to do the same things. But you may look into this tutorial 
+to understand what's going on under the hood of the plugin.
 
 To be able to build the application for production the web files should be 
 transpiled and copied into the directory that is used by Flow in production mode to serve files from.

--- a/web-components/tutorial-flow-webjars.asciidoc
+++ b/web-components/tutorial-flow-webjars.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: WebJars in Flow
-order: 5
+order: 4
 layout: page
 ---
 

--- a/web-components/tutorial-how-to-use-webjars.asciidoc
+++ b/web-components/tutorial-how-to-use-webjars.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: How to use WebJars
-order: 6
+order: 5
 layout: page
 ---
 

--- a/web-components/tutorial-webcomponent-basic.asciidoc
+++ b/web-components/tutorial-webcomponent-basic.asciidoc
@@ -35,9 +35,8 @@ You specify the tag name of the element using the `@Tag` annotation, just like y
 [NOTE]
 If you are using some skeleton project or a demo such as https://github.com/vaadin/skeleton-starter-flow[`skeleton-starter-flow`] as a starting point, you probably have everything already configured. In this case, you can skip to <<Installing the Web Component>>.
 
-The imported file `paper-slider.html` contains a client side code which needs to be available as a web resource. 
-The best way to do it is to use webjars. In order to add a webjar into the project, 
-you have to simply specify a project dependency.
+The imported file `paper-slider.html` contains client side code which needs to be available as a web resource. 
+The recommended way to do it is to use webjars. To add a webjar to the project you only need to specify it as a project dependency.
 Maven example:
 
 [source,xml]

--- a/web-components/tutorial-webcomponent-basic.asciidoc
+++ b/web-components/tutorial-webcomponent-basic.asciidoc
@@ -21,7 +21,7 @@ The Java class for integrating  https://elements.polymer-project.org/elements/pa
 [source,java]
 ----
 @Tag("paper-slider")
-@HtmlImport("bower_components/paper-slider/paper-slider.html")
+@HtmlImport("frontend://bower_components/paper-slider/paper-slider.html")
 public class PaperSlider extends Component {
     public PaperSlider() {
     }
@@ -35,126 +35,25 @@ You specify the tag name of the element using the `@Tag` annotation, just like y
 [NOTE]
 If you are using some skeleton project or a demo such as https://github.com/vaadin/skeleton-starter-flow[`skeleton-starter-flow`] as a starting point, you probably have everything already configured. In this case, you can skip to <<Installing the Web Component>>.
 
-The imported file `paper-slider.html` contains a client side code which needs to be available as a web resource. So it should be
-fetched and saved in some directory which is served by your server.
-If you use maven then just add  the following snippet in your `pom.xml` file inside your `plugins` section:
+The imported file `paper-slider.html` contains a client side code which needs to be available as a web resource. 
+The best way to do it is to use webjars. In order to add a webjar into the project, 
+you have to simply specify a project dependency.
+Maven example:
 
 [source,xml]
 ----
-    <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>${frontend.maven.plugin.version}</version>
-        <configuration>
-            <nodeVersion>${node.version}</nodeVersion>
-            <npmVersion>${npm.version}</npmVersion>
-        </configuration>
-        <executions>
-            <execution>
-                <id>install-node-and-npm</id>
-                <goals>
-                    <goal>install-node-and-npm</goal>
-                    <goal>npm</goal> <!-- runs 'install' by default -->
-                    <goal>bower</goal> <!-- runs 'install' by default -->
-                </goals>
-                <configuration>
-                    <workingDirectory>${frontend.working.directory}</workingDirectory>
-                </configuration>
-            </execution>
-        </executions>
-    </plugin>
-----
-
-This plugin will install for you tools for webcomponents management (`npm` and `bower`) assuming you are using
-`${frontend.working.directory}` directory as a web resource directory in your project.
-
-[NOTE]
-The default for `${frontend.working.directory}` is `src/main/webapp/frontend`, but you can pick any directory you want.
-
-This directory should have files `bower.json` and `package.json`.
-
-The `bower.json` content is a file where you list all the dependencies you need from the frontend part of the application:
-
-[source,json]
-----
-{
-  "name": "your project name",
-  "homepage": "",
-  "authors": [],
-  "description": "",
-  "main": "",
-  "license": "Apache2",
-  "private": true,
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
-  "dependencies": {
-    "polymer": "~2.0.2",
-    "paper-slider": "~2.0.0"
-  }
-}
+<dependency>
+    <groupId>org.webjars.bower</groupId>
+    <artifactId>paper-slider</artifactId>
+    <version>2.0.2</version>
+</dependency>
 ----
 
 [NOTE]
-This file is processed with `bower` utility to download web components. If you have it preinstalled, you may want to skip the next step.
-For further info on the file contents, please refer to https://github.com/bower/spec/blob/master/json.md[bower.json file specification]
-
-To download `bower`, another file is used: `package.json`
-The file contents looks the following way:
-
-[source,json]
-----
-{
-  "name": "your project name",
-  "version": "1.0.0",
-  "main": "",
-  "dependencies": {
-    "bower": "~1.8.2"
-  },
-  "scripts": {
-  },
-  "author": "",
-  "license": "Apache-2.0"
-}
-----
+Please see <<tutorial-flow-webjars#,Webjars in Flow>> tutorial explaining all details about webjars.
 
 [NOTE]
-Current situation (using different files for downloading dependencies) will be different in future, when https://www.polymer-project.org/blog/2017-08-23-hands-on-30-preview[Polymer 3.0] will be released.
-For further info on the file contents, please refer to https://docs.npmjs.com/files/package.json[package.json file specification]
-
-[NOTE] Workflows not using Maven are not supported at the moment. If your project doesn't use Maven, you will need to install and run `bower` directly, which is described bellow.
-
-In this example it is assumed that you are using bower and have a `bower_components` directory in the root of you `WAR` file.
-
-You can set up the `bower_components` and `bower.json` manually by running
-
-[source,sh]
-----
-bower init
-----
-
-[NOTE]
-To install `bower`, you first need to install _Node.js_ through a https://nodejs.org/en/download/package-manager/[package manager] or by https://nodejs.org/en/download/[downloading the installer].
-You can then install `bower` by running `npm install -g bower`.
-
-`bower init` will ask a you couple of questions and it creates the `bower.json` file.
-The default answers for all the questions are suitable for this kind of integration, so you can simply proceed by pressing `enter` to accept each default answer.
-
-== Installing the Web Component
-
-Running the following command in `${frontend.working.directory}` will install the `paper-slider` component.
-
-[source,sh]
-----
-bower install paper-slider --save
-----
-
-[NOTE]
-You can also install web components by manually adding dependencies to the `bower.json` file and running `bower install`, which will download all the dependencies declared in the file.
+Another (outdated) way to make the web component files available as a web resource is described in <<tutorial-utorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
 
 With this basic integration, you can use add the `PaperSlider` class to a view to see that it works:
 [source,java]

--- a/web-components/tutorial-webcomponent-basic.asciidoc
+++ b/web-components/tutorial-webcomponent-basic.asciidoc
@@ -53,7 +53,7 @@ Maven example:
 Please see <<tutorial-flow-webjars#,Webjars in Flow>> tutorial explaining all details about webjars.
 
 [NOTE]
-Another (outdated) way to make the web component files available as a web resource is described in <<tutorial-utorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
+Another (outdated) way to make the web component files available as a web resource is described in <<tutorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
 
 With this basic integration, you can use add the `PaperSlider` class to a view to see that it works:
 [source,java]

--- a/web-components/tutorial-webcomponents-bower.asciidoc
+++ b/web-components/tutorial-webcomponents-bower.asciidoc
@@ -1,0 +1,139 @@
+---
+title: Using bower to make available a web component as a web resource
+order: 8
+layout: page
+---
+
+ifdef::env-github[:outfilesuffix: .asciidoc]
+= Using bower to make available a web component as a web resource
+
+This is an old and deprecated way to make available a web component as a web resource.
+It's highly recommended to use webjars instead. See <<tutorial-webcomponent-basic#,Basic Integration of a Polymer Web Component>>
+and <<tutorial-flow-webjars#,Webjars in Flow>> tutorials about using webjars.
+
+If you for some reasons don't want to use webjars then it's possible to make
+available a web resource installing web component files locally (via `bower`) and package
+them along with your application. 
+You may want to do this e.g. if you want to be able to change web component source files
+(which is impossible if you are using webjar where they are packaged in binary archive).
+
+To be able to get the web component files locally they need to be fetched and
+and saved in some directory which is served by your server.
+If you use maven then just add the following snippet in your `pom.xml` file inside your `plugins` section:
+
+[source,xml]
+----
+    <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${frontend.maven.plugin.version}</version>
+        <configuration>
+            <nodeVersion>${node.version}</nodeVersion>
+            <npmVersion>${npm.version}</npmVersion>
+        </configuration>
+        <executions>
+            <execution>
+                <id>install-node-and-npm</id>
+                <goals>
+                    <goal>install-node-and-npm</goal>
+                    <goal>npm</goal> <!-- runs 'install' by default -->
+                    <goal>bower</goal> <!-- runs 'install' by default -->
+                </goals>
+                <configuration>
+                    <workingDirectory>${frontend.working.directory}</workingDirectory>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin>
+----
+
+This plugin will install for you tools for webcomponents management (`npm` and `bower`) assuming you are using
+`${frontend.working.directory}` directory as a web resource directory in your project.
+
+[NOTE]
+The default for `${frontend.working.directory}` is `src/main/webapp/frontend`, but you can pick any directory you want.
+
+This directory should have files `bower.json` and `package.json`.
+
+The `bower.json` content is a file where you list all the dependencies you need from the frontend part of the application:
+
+[source,json]
+----
+{
+  "name": "your project name",
+  "homepage": "",
+  "authors": [],
+  "description": "",
+  "main": "",
+  "license": "Apache2",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "polymer": "~2.0.2",
+    "paper-slider": "~2.0.0"
+  }
+}
+----
+
+[NOTE]
+This file is processed with `bower` utility to download web components. If you have it preinstalled, you may want to skip the next step.
+For further info on the file contents, please refer to https://github.com/bower/spec/blob/master/json.md[bower.json file specification]
+
+To download `bower`, another file is used: `package.json`
+The file contents looks the following way:
+
+[source,json]
+----
+{
+  "name": "your project name",
+  "version": "1.0.0",
+  "main": "",
+  "dependencies": {
+    "bower": "~1.8.2"
+  },
+  "scripts": {
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}
+----
+
+[NOTE]
+Current situation (using different files for downloading dependencies) will be different in future, when https://www.polymer-project.org/blog/2017-08-23-hands-on-30-preview[Polymer 3.0] will be released.
+For further info on the file contents, please refer to https://docs.npmjs.com/files/package.json[package.json file specification]
+
+[NOTE] Workflows not using Maven are not supported at the moment. If your project doesn't use Maven, you will need to install and run `bower` directly, which is described bellow.
+
+In this example it is assumed that you are using bower and have a `bower_components` directory in the root of you `WAR` file.
+
+You can set up the `bower_components` and `bower.json` manually by running
+
+[source,sh]
+----
+bower init
+----
+
+[NOTE]
+To install `bower`, you first need to install _Node.js_ through a https://nodejs.org/en/download/package-manager/[package manager] or by https://nodejs.org/en/download/[downloading the installer].
+You can then install `bower` by running `npm install -g bower`.
+
+`bower init` will ask a you couple of questions and it creates the `bower.json` file.
+The default answers for all the questions are suitable for this kind of integration, so you can simply proceed by pressing `enter` to accept each default answer.
+
+== Installing the Web Component
+
+Running the following command in `${frontend.working.directory}` will install the `paper-slider` component.
+
+[source,sh]
+----
+bower install paper-slider --save
+----
+
+[NOTE]
+You can also install web components by manually adding dependencies to the `bower.json` file and running `bower install`, which will download all the dependencies declared in the file.

--- a/web-components/tutorial-webcomponents-bower.asciidoc
+++ b/web-components/tutorial-webcomponents-bower.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Using bower to make available a web component as a web resource
-order: 8
+order: 7
 layout: page
 ---
 

--- a/web-components/tutorial-webcomponents-es5.asciidoc
+++ b/web-components/tutorial-webcomponents-es5.asciidoc
@@ -1,43 +1,45 @@
 ---
 title: Serving ECMAScript 5 webcomponents with Polymer 2
-order: 4
+order: 8
 layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
 = Serving ECMAScript 5 webcomponents with Polymer 2
 
-According to the native custom element specification, ECMAScript 6 is required
-to define webcomponents. But when deploying an application to IE11 and Safari 9,
- you need to transpile the files to ECMAScript 5 (ES5 for short), since those
-browsers don't support ECMAScript 6. Luckily there's a library that can transpile
-and optimize the ES6 files to ES5, which is provided by the Polymer project:
-polymer-build.
-
-[TIP]
-Transpilation in current context is converting ES6 JavaScript code to ES5 that is performed for older browsers be able to run it
+As mentioned in the <<tutorial-flow-maven-plugin#,Taking your app into production>>
+tutorial transpilation to ECMAScript 5 is required to use an application with browsers that don’t support ES6.  
+Luckily there's a library that can transpile and optimize the ES6 files to ES5, which is provided by the Polymer project:
+`polymer-build`.
 
 [TIP]
 The same library can also be used to optimize ES6 scripts, by using minification.
 
 == Project structure
 
-After following the steps described in <<tutorial-webcomponent-basic#,Basic Integration of a Polymer Web Component>>
-the project has `bower.json`, `package.json` files and `bower_components` folder with all web components and their dependencies in `${frontend.working.directory}` folder.
-You can also have a separate folder for your static files with other html/css/js files, usually that one is located in `src/main/webapp/` folder of the application.
+You will need `bower.json`, `package.json` files and `bower_components` folder with all web components and their dependencies in `${frontend.working.directory}` folder.
+<<web-components/tutorial-webcomponents-bower#,Using bower to make available a web component as a web resource>> tutorial
+explains the content of those files and the way how to fetch web components into
+`bower_components` via `bower`.
+In this example `src/main/resources/META-INF/resources/` directory will be used for web resources instead of `src/main/webapp`
+to make possible package the project also as JAR (in case of WAR this folder will be set as a web resource). 
+You can also have a separate folder for your static files with other html/css/js files, usually that one is located in 
+web resources folder of the application (which is `src/main/resources/META-INF/resources/` in our case).
 We will consider this folder further, since the code from there would like to use dependencies from `${frontend.working.directory}/bower_components` folder.
 
-If we consider `${frontend.working.directory}` to be located at `src/main/webapp/frontend`, we get the following structure:
+If we consider `${frontend.working.directory}` to be located at `src/main/resources/META-INF/resources/frontend`, we get the following structure:
 
 * project-root/
 ** src/main/
 *** java/ - Your Java code
-*** webapp/ - Static files not associated to webcomponents (such as images, favicon, files for download and so on)
-**** static_file.js – should be able to reference files from `bower_components`
-**** frontend/ - Root path of your webcomponents
-***** bower_components/ - `bower` output directory containing all web components declared in `bower.json`
-***** bower.json - a file with dependencies' declaration
-***** package.json - a file for automatic `bower` downloading
+*** resources/ - Resources root of your Java application
+**** META-INF/ - META-INF folder
+***** resources/ - Resources folder, static files not associated to webcomponents (such as images, favicon, files for download and so on)
+****** static_file.js – should be able to reference files from `bower_components`
+****** frontend/ - Root path of your webcomponents
+******* bower_components/ - `bower` output directory containing all web components declared in `bower.json`
+******* bower.json - a file with dependencies' declaration
+******* package.json - a file for automatic `bower` downloading
 ** src/test/java/ - Your tests
 ** target/ - Your output directory
 ** pom.xml - Your project definition Maven file
@@ -49,7 +51,7 @@ In your `${frontend.working.directory}` directory, you have to update `package.j
 
 ==== package.json
 
-Initial file state is described in <<tutorial-webcomponent-basic#,Basic Integration of a Polymer Web Component>>
+Initial file state is described in <<web-components/tutorial-webcomponents-bower#,Using bower to make available a web component as a web resource>>
 We have added and `polymer-cli` dependencies that will process our web files and have added two tasks: `prodMode` and `devMode`
 Both tasks run `bower install` to install dependencies from `bower.json` and `prodMode` also runs `polymer build` that
 uses installed `polymer-cli` tool to transpile the sources to ES5:.
@@ -190,16 +192,16 @@ After all changes and package being run, the project structure would be the foll
 * project-root/
 ** src/main/
 *** java/ - Your Java code
-*** webapp/ - Static files not associated to webcomponents (such as images, favicon, files for download and so on)
-**** static_file.js – should be able to reference files from `bower_components`
-**** frontend/ - Root path of your webcomponents
-***** bower_components/ - `bower` output directory containing all web components declared in `bower.json`
-***** bower.json - a file with dependencies' declaration
-***** package.json - a file for automatic `bower` downloading
-***** polymer.json - a file that describes how the resources should be processed (minified and/or transpiled)
-***** index.html - a file that contains urls to all dependencies that are needed to be processed
-***** build/frontend-es5/ - transpiled and minified files for older browsers
-***** build/frontend-es6/ - minified files for newer browsers
+*** resources/ - Resources root of your Java application
+**** META-INF/ - META-INF folder
+***** resources/ - Resources folder, static files not associated to webcomponents (such as images, favicon, files for download and so on)
+****** static_file.js – should be able to reference files from `bower_components`
+****** frontend/ - Root path of your webcomponents
+******* bower_components/ - `bower` output directory containing all web components declared in `bower.json`
+******* bower.json - a file with dependencies' declaration
+******* package.json - a file for automatic `bower` downloading
+******* build/frontend-es5/ - transpiled and minified files for older browsers
+******* build/frontend-es6/ - minified files for newer browsers
 ** src/test/java/ - Your tests
 ** target/ - Your output directory
 ** pom.xml - Your project definition Maven file
@@ -220,11 +222,11 @@ Jetty Plugin by using the `mvn jetty:run` command.
 [source,xml]
 ----
 <properties>
-  <frontend.working.directory>${project.basedir}/src/main/webapp/frontend</frontend.working.directory>
+  <frontend.working.directory>${project.basedir}/src/main/resources/META-INF/resources/frontend</frontend.working.directory>
 
-  <jetty.extra.resource.base>${frontend.working.directory}</jetty.extra.resource.base>
+  <jetty.extra.resource.base>${project.basedir}/src/main/resources/META-INF/resources</jetty.extra.resource.base>
   <npm.build.goal>run devMode</npm.build.goal>
-  <war.excludes>**/node_modules/,**/node/,**/build/,**/etc/</war.excludes>
+  <war.excludes>**/node_modules/,**/node/,**/build/,**/etc/,**/package.json,**/bower.json,**/polymer.json</war.excludes>
 </properties>
 
 <build>
@@ -295,7 +297,7 @@ Jetty Plugin by using the `mvn jetty:run` command.
                   <containerIncludeJarPattern>^$</containerIncludeJarPattern>
                   <resourceBases>
                       <resourceBase>${jetty.extra.resource.base}</resourceBase>
-                      <resourceBase>${project.basedir}src/main/webapp</resourceBase>
+                      <resourceBase>${project.basedir}/src/main/resources/META-INF/resources</resourceBase>
                   </resourceBases>
               </webAppConfig>
           </configuration>
@@ -320,6 +322,9 @@ Jetty Plugin by using the `mvn jetty:run` command.
                           <exclude>**/node/</exclude>
                           <exclude>**/node_modules/</exclude>
                           <exclude>**/etc/</exclude>
+                          <exclude>**/package.json</exclude>
+                          <exclude>**/bower.json</exclude>
+                          <exclude>**/polymer.json</exclude>
                       </excludes>
                   </resource>
               </webResources>
@@ -343,7 +348,7 @@ Jetty Plugin by using the `mvn jetty:run` command.
         <!-- Overrides properties that are different for produciton mode -->
         <npm.build.goal>run prodMode</npm.build.goal>
         <jetty.extra.resource.base>${frontend.working.directory}/build</jetty.extra.resource.base>
-        <war.excludes>**/frontend/bower_components/,**/node_modules/,**/node/,**/build/,**/etc/</war.excludes>
+        <war.excludes>**/frontend/bower_components/,**/node_modules/,**/node/,**/build/,**/etc/,**/package.json,**/bower.json,**/polymer.json</war.excludes>
     </properties>
 
     <!-- Makes the package run in production mode when deployed, without the need of setting extra properties on the server -->
@@ -357,6 +362,17 @@ Jetty Plugin by using the `mvn jetty:run` command.
   </profile>
 </profiles>
 ----
+
+The important things in this configuration are:
+
+* Folder `src/main/resources/META-INF/resources` (which is the value of `jetty.extra.resource.base` property) 
+is set as a web resource for Jetty plugin and maven WAR plugin in the default profile
+(so this folder will be used instead of `src/main/webapp`).
+* `jetty.extra.resource.base` property gets value `${frontend.working.directory}/build` in `productionMode` profile.
+
+When application is executed in production mode `frontend-es6` and `frontend-es5` folders 
+in web resources folder (which is `${frontend.working.directory}/build` in this case) 
+will be used to resolve HMTL import URLs. You can find details below.  
 
 [TIP]
 There is <<tutorial-flow-maven-plugin#,Taking your app into production>> tutorial available which shows how 
@@ -438,7 +454,7 @@ Relative paths in your `@HtmlImport`, `@JavaScript` and `@StyleSheet` annotation
 [source,java]
 ----
 @Tag("my-component")
-@HtmlImport("components/my-component.html")
+@HtmlImport("frontend/components/my-component.html")
 public class MyComponent extends PolymerTemplate<MyModel> {
 ----
 
@@ -455,7 +471,8 @@ That way you can support ES5 browsers without compromising ES6 capable browsers.
 [NOTE]
 The differentiation between ES5 and ES6 paths only occur when `productionMode` is
 `true`. When running in debug (or development) mode, the `frontend://` protocol
-behaves exactly like the `context://` protocol, and the files are served directly
+behaves like the `context://frontend/` protocol (so it resolves URLs to `frontend` 
+folder of the `(context)` location), and the files are served directly
 from `${frontend.working.directory}`.
 
 === Changing the location of frontend files
@@ -471,9 +488,17 @@ More details on parameters can be found in <<../advanced/tutorial-flow-runtime-c
 
 When you set, for example, your `frontend.url.es6` property to
 `http://mydomain.com/es6/`, the resulting URL for a component annotated with
-`@HTMLImport("components/my-component.html")` or
-`@HTMLImport("frontend://components/my-component.html")` will be
+`@HTMLImport("components/my-component.html")` will be
 `http://mydomain.com/es6/components/my-component.html`.
+
+In the example above we have used a different value for `jetty.extra.resource.base` property in production mode.
+Another option would be to keep it's value as is but define properties to run the application
+in production mode (this way may be useful in case when you can't redefine web resources e.g. in Spring Boot application):
+
+ [source,bash]
+----
+mvn jetty:run -Dvaadin.productionMode -Dvaadin.frontend.url.es5=context://frontend/build/frontend-es5/ -Dvaadin.frontend.url.es6=context://frontend/build/frontend-es6/
+----
 
 [WARNING]
 The base path defined by `frontend.url.es6` and `frontend.url.es5` properties

--- a/web-components/tutorial-webcomponents-es5.asciidoc
+++ b/web-components/tutorial-webcomponents-es5.asciidoc
@@ -454,7 +454,7 @@ Relative paths in your `@HtmlImport`, `@JavaScript` and `@StyleSheet` annotation
 [source,java]
 ----
 @Tag("my-component")
-@HtmlImport("frontend/components/my-component.html")
+@HtmlImport("components/my-component.html")
 public class MyComponent extends PolymerTemplate<MyModel> {
 ----
 
@@ -488,7 +488,8 @@ More details on parameters can be found in <<../advanced/tutorial-flow-runtime-c
 
 When you set, for example, your `frontend.url.es6` property to
 `http://mydomain.com/es6/`, the resulting URL for a component annotated with
-`@HTMLImport("components/my-component.html")` will be
+`@HTMLImport("components/my-component.html")` or
+`@HTMLImport("frontend://components/my-component.html")` will be 
 `http://mydomain.com/es6/components/my-component.html`.
 
 In the example above we have used a different value for `jetty.extra.resource.base` property in production mode.


### PR DESCRIPTION
Make webjars as a recommended way to use webcomponents.
Make bower based tutorial deprecated.
Make maven plugin as a recommended way to set up project for production.
Make old transpilation tutorial optional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/9)
<!-- Reviewable:end -->
