### PR TITLE
use the correct terms in the ECMAScript 2015 / ES5 / ES6 context

### DIFF
--- a/web-components/tutorial-flow-maven-plugin.asciidoc
+++ b/web-components/tutorial-flow-maven-plugin.asciidoc
@@ -7,13 +7,11 @@ layout: page
 ifdef::env-github[:outfilesuffix: .asciidoc]
 = Taking your app into production
 
-According to the native custom element specification, ECMAScript 6 is required
-to define webcomponents. But when deploying an application to IE11 and Safari 9,
- you need to transpile the files to ECMAScript 5 (ES5 for short), since those
-browsers don't support ECMAScript 6.
+According to the link:https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements[Custom Elements^] specification, a JavaScript *class* is required
+when defining a custom element. Classes are added to JavaScript in the ECMAScript 2015 standard (a.k.a. ES6). However, some older browsers--most notably IE11 and Safari 9--do not support it. For those browsers you need to transpile the files to ECMAScript 5.1 (a.k.a. ES5).
 
 [TIP]
-Transpilation in current context is converting ES6 JavaScript code to ES5 that is performed for older browsers be able to run it.
+Transpilation in the current context means converting ES6 JavaScript code to its ES5 equivalent. It is done in order to run this code in older browsers.
 
 You may also want to optimize web files (reduce a number of files and optimize their content) via bundling.
 In this case we provide `flow-maven-plugin` which sets up the project for the production mode.

--- a/web-components/tutorial-webcomponents-es5.asciidoc
+++ b/web-components/tutorial-webcomponents-es5.asciidoc
@@ -1,14 +1,14 @@
 ---
-title: Serving ECMAScript 5 webcomponents with Polymer 2
+title: Serving ES5 Web Components with Polymer 2
 order: 8
 layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
-= Serving ECMAScript 5 webcomponents with Polymer 2
+= Serving ES5 Web Components with Polymer 2
 
 As mentioned in the <<tutorial-flow-maven-plugin#,Taking your app into production>>
-tutorial transpilation to ECMAScript 5 is required to use an application with browsers that don’t support ES6.  
+tutorial transpilation to ES5 is required to use an application with browsers that don’t support ES6.  
 Luckily there's a library that can transpile and optimize the ES6 files to ES5, which is provided by the Polymer project:
 `polymer-build`.
 

--- a/web-components/tutorial-webcomponents-es5.asciidoc
+++ b/web-components/tutorial-webcomponents-es5.asciidoc
@@ -1,14 +1,14 @@
 ---
-title: Serving ES5 Web Components with Polymer 2
+title: Serving ECMAScript 5 webcomponents with Polymer 2
 order: 8
 layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
-= Serving ES5 Web Components with Polymer 2
+= Serving ECMAScript 5 webcomponents with Polymer 2
 
 As mentioned in the <<tutorial-flow-maven-plugin#,Taking your app into production>>
-tutorial transpilation to ES5 is required to use an application with browsers that don’t support ES6.  
+tutorial transpilation to ECMAScript 5 is required to use an application with browsers that don’t support ES6.  
 Luckily there's a library that can transpile and optimize the ES6 files to ES5, which is provided by the Polymer project:
 `polymer-build`.
 


### PR DESCRIPTION
 - ES6 is a 'marketing' term - the standard is ECMAScript 2015 (or ECMAScript 2016, or newer)
 - ES5 refers to ECMAScript 5.1, not 5
 - add a link to the Custom Elements docs on MDN

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/19)
<!-- Reviewable:end -->
