### PR TITLE
Update tutorial-ways-of-importing.asciidoc

### DIFF
--- a/importing-dependencies/tutorial-ways-of-importing.asciidoc
+++ b/importing-dependencies/tutorial-ways-of-importing.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: Importing HTML and JavaScript
+title: Ways of Importing the Dependencies
 order: 2
 layout: page
 ---


### PR DESCRIPTION
The header "Importing HTML and JavaScript" is twice in the menu. I suspect that the file was copy pasted and the "title:" was not updated. I switched it to the h1 for the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/22)
<!-- Reviewable:end -->
