### PR TITLE
Remove references to Vaadin Elements, use "components" term instead

### DIFF
--- a/components/tutorial-flow-components-setup.asciidoc
+++ b/components/tutorial-flow-components-setup.asciidoc
@@ -6,31 +6,31 @@ layout: page
 
 = Using Vaadin Components
 
-There is a set of pre-built server-side components with Java API for https://vaadin.com/elements/browse[Vaadin Web Components],
+There is a set of pre-built server-side components with Java API for https://vaadin.com/components/browse[Vaadin Web Components],
 such as `Button`, `TextField` and so on. Those components are part of the Vaadin 10 platform,
 and are included as dependencies in the platform together with Flow.
 
 The platform has the following components with Java API available:
 
-- `Button` - https://vaadin.com/elements/vaadin-button/java-examples[Demos], https://github.com/vaadin/vaadin-button-flow[sources and issue tracking]
-- `CheckBox` - https://vaadin.com/elements/vaadin-checkbox/java-examples[Demos], https://github.com/vaadin/vaadin-checkbox-flow[sources and issue tracking]
-- `ComboBox` - https://vaadin.com/elements/vaadin-combo-box/java-examples[Demos], https://github.com/vaadin/vaadin-combo-box-flow[sources and issue tracking]
-- `DatePicker` - https://vaadin.com/elements/vaadin-date-picker/java-examples[Demos], https://github.com/vaadin/vaadin-date-picker-flow[sources and issue tracking]
-- `Dialog` - https://vaadin.com/elements/vaadin-dialog/java-examples[Demos], https://github.com/vaadin/vaadin-dialog-flow[sources and issue tracking]
-- `FormLayout` - https://vaadin.com/elements/vaadin-form-layout/java-examples[Demos], https://github.com/vaadin/vaadin-form-layout-flow[sources and issue tracking]
-- `Grid` - https://vaadin.com/elements/vaadin-grid/java-examples[Demos], <<tutorial-flow-grid#,Documentation>>, https://github.com/vaadin/vaadin-grid-flow[sources and issue tracking]
-- `Icons` - https://vaadin.com/elements/vaadin-icons/java-examples[Demos], <<tutorial-flow-icon#,Documentation>>, https://github.com/vaadin/vaadin-icons-flow[sources and issue tracking]
+- `Button` - https://vaadin.com/components/vaadin-button/java-examples[Demos], https://github.com/vaadin/vaadin-button-flow[sources and issue tracking]
+- `CheckBox` - https://vaadin.com/components/vaadin-checkbox/java-examples[Demos], https://github.com/vaadin/vaadin-checkbox-flow[sources and issue tracking]
+- `ComboBox` - https://vaadin.com/components/vaadin-combo-box/java-examples[Demos], https://github.com/vaadin/vaadin-combo-box-flow[sources and issue tracking]
+- `DatePicker` - https://vaadin.com/components/vaadin-date-picker/java-examples[Demos], https://github.com/vaadin/vaadin-date-picker-flow[sources and issue tracking]
+- `Dialog` - https://vaadin.com/components/vaadin-dialog/java-examples[Demos], https://github.com/vaadin/vaadin-dialog-flow[sources and issue tracking]
+- `FormLayout` - https://vaadin.com/components/vaadin-form-layout/java-examples[Demos], https://github.com/vaadin/vaadin-form-layout-flow[sources and issue tracking]
+- `Grid` - https://vaadin.com/components/vaadin-grid/java-examples[Demos], <<tutorial-flow-grid#,Documentation>>, https://github.com/vaadin/vaadin-grid-flow[sources and issue tracking]
+- `Icons` - https://vaadin.com/components/vaadin-icons/java-examples[Demos], <<tutorial-flow-icon#,Documentation>>, https://github.com/vaadin/vaadin-icons-flow[sources and issue tracking]
 - `IronList` - https://github.com/vaadin/vaadin-iron-list-flow[examples, sources and issue tracking]
-// TODO enable demo link https://vaadin.com/elements/vaadin-notification/java-examples[Demos],
+// TODO enable demo link https://vaadin.com/components/vaadin-notification/java-examples[Demos],
 - `Notification` - https://github.com/vaadin/vaadin-notification-flow[sources and issue tracking]
-// TODO enable demo link https://vaadin.com/elements/vaadin-ordered-layout/java-examples[Demos]
+// TODO enable demo link https://vaadin.com/components/vaadin-ordered-layout/java-examples[Demos]
 - `HorizontalLayout` & `VerticalLayout` & `FlexLayout` - https://github.com/vaadin/vaadin-ordered-layout-flow[sources and issue tracking]
-- `ProgressBar` - https://vaadin.com/elements/vaadin-progress-bar/java-examples[Demos], https://github.com/vaadin/vaadin-progress-bar-flow[sources and issue tracking]
-- `SplitLayout` - https://vaadin.com/elements/vaadin-split-layout/java-examples[Demos], https://github.com/vaadin/vaadin-split-layout-flow[sources and issue tracking]
-// TODO enable demo link https://vaadin.com/elements/vaadin-tabs/java-examples[Demos],
+- `ProgressBar` - https://vaadin.com/components/vaadin-progress-bar/java-examples[Demos], https://github.com/vaadin/vaadin-progress-bar-flow[sources and issue tracking]
+- `SplitLayout` - https://vaadin.com/components/vaadin-split-layout/java-examples[Demos], https://github.com/vaadin/vaadin-split-layout-flow[sources and issue tracking]
+// TODO enable demo link https://vaadin.com/components/vaadin-tabs/java-examples[Demos],
 - `Tabs` - https://github.com/vaadin/vaadin-tabs-flow[sources and issue tracking]
-- `TextField` & `TextArea` & `PasswordField` - https://vaadin.com/elements/vaadin-text-field/java-examples[Demos], https://github.com/vaadin/vaadin-text-field-flow[sources and issue tracking]
-- `Upload` - https://vaadin.com/elements/vaadin-upload/java-examples[Demos], https://github.com/vaadin/vaadin-upload-flow[sources and issue tracking]
+- `TextField` & `TextArea` & `PasswordField` - https://vaadin.com/components/vaadin-text-field/java-examples[Demos], https://github.com/vaadin/vaadin-text-field-flow[sources and issue tracking]
+- `Upload` - https://vaadin.com/components/vaadin-upload/java-examples[Demos], https://github.com/vaadin/vaadin-upload-flow[sources and issue tracking]
 
 
 When you use the Vaadin 10 platform dependency, you automatically get *ALL* available components.

--- a/introduction/introduction-overview.asciidoc
+++ b/introduction/introduction-overview.asciidoc
@@ -35,7 +35,7 @@ On top of ready-made components, there are powerful abstraction layers that can 
 
 === Vaadin Components
 
-On the high abstraction layer, you can build UIs, in a highly productive way, by using the Java APIs of Vaadin Components based on the Vaadin Elements Web Components.
+On the high abstraction layer, you can build UIs, in a highly productive way, by using the Java APIs for Vaadin's Web Components.
 This way you don't have to write or understand any JavaScript or HTML, and CSS is only necessary to give your App the look and feel you want to.
 
 [source,java]

--- a/introduction/tutorial-get-started.asciidoc
+++ b/introduction/tutorial-get-started.asciidoc
@@ -181,7 +181,7 @@ components. Layouts are used to position and display other components.
 
 The third annotation, [classname]#@Theme("Lumo.class")#, defines the component theme to use.
 Using this annotation on the root level navigation target or root layout will enable the Lumo theme
-for all used Vaadin Elements automatically. You can read more about Web Component themes and Lumo from https://vaadin.com/themes.
+for all used Vaadin components automatically. You can read more about Web Component themes and Lumo from https://vaadin.com/themes.
 
 Finally, the third annotation [classname]#@BodySize(height = "100vh", width = "100vw")#
 defines the _styles_ that are set to the `<body>` element to make it resize nicely on all devices.

--- a/migration/5-components.asciidoc
+++ b/migration/5-components.asciidoc
@@ -23,33 +23,33 @@ The following table lists the existing Vaadin 8 components and their direct repl
 
 | Audio | - | Not planned. Can directly use the native `<audio>` element.
 
-| Button | Button | https://vaadin.com/elements/vaadin-button/java-examples[Demo]
+| Button | Button | https://vaadin.com/components/vaadin-button/java-examples[Demo]
 
-| Checkbox | Checkbox | https://vaadin.com/elements/vaadin-checkbox/java-examples[Demo]
+| Checkbox | Checkbox | https://vaadin.com/components/vaadin-checkbox/java-examples[Demo]
 
 | CheckBoxGroup | - | Planned, no timeline yet. For now, this can be manually assembled from CheckBoxes on server side
 
 | ColorPicker | - | Not planned. See https://vaadin.com/directory[vaadin.com/directory]. `<input type="color">` is supported in some browsers.
 
-| ComboBox | ComboBox | https://vaadin.com/elements/vaadin-combo-box/java-examples[Demo]. Note that the V10 ComboBox is not lazy-loading between server and client
+| ComboBox | ComboBox | https://vaadin.com/components/vaadin-combo-box/java-examples[Demo]. Note that the V10 ComboBox is not lazy-loading between server and client
 
 | CustomComponent | Composite | <<../creating-components/tutorial-component-composite#,Tutorial>>
 
 | CssLayout | Div & FlexLayout | More details <<#layouts,later in this chapter>>
 
-| DateField | DatePicker | https://vaadin.com/elements/vaadin-date-picker/java-examples[Demo]
+| DateField | DatePicker | https://vaadin.com/components/vaadin-date-picker/java-examples[Demo]
 
 | DateTimeField | - | Planned, but no timeline yet. `<input type="datetime"> is supported in some browsers.
 
-| FormLayout | FormLayout | https://vaadin.com/elements/vaadin-form-layout/java-examples[Demo]
+| FormLayout | FormLayout | https://vaadin.com/components/vaadin-form-layout/java-examples[Demo]
 
-| Grid | Grid | https://vaadin.com/elements/vaadin-grid/java-examples[Demo], <<../components/tutorial-flow-grid#,Tutorial>>
+| Grid | Grid | https://vaadin.com/components/vaadin-grid/java-examples[Demo], <<../components/tutorial-flow-grid#,Tutorial>>
 
 | GridLayout | - | Not planned. FormLayout, FlexLayout and Board can be used as replacements for many of the use cases
 
-| HorizontalLayout | HorizontalLayout | https://vaadin.com/elements/vaadin-ordered-layout/java-examples[Demo], more details <<#layouts,later in this chapter>>
+| HorizontalLayout | HorizontalLayout | https://vaadin.com/components/vaadin-ordered-layout/java-examples[Demo], more details <<#layouts,later in this chapter>>
 
-| HorizontalSplitPanel | SplitLayout | https://vaadin.com/elements/vaadin-split-layout/java-examples[Demo]
+| HorizontalSplitPanel | SplitLayout | https://vaadin.com/components/vaadin-split-layout/java-examples[Demo]
 
 | Image | Image | -
 
@@ -59,7 +59,7 @@ The following table lists the existing Vaadin 8 components and their direct repl
 
 | Label | Label | -
 
-| ListSelect | ListBox | https://vaadin.com/elements/vaadin-list-box/java-examples[Demo]
+| ListSelect | ListBox | https://vaadin.com/components/vaadin-list-box/java-examples[Demo]
 
 | MenuBar | - | No plans for replacement.
 
@@ -67,27 +67,27 @@ The following table lists the existing Vaadin 8 components and their direct repl
 
 | NativeSelect | - | Planned, by new component `DropdownMenu`. Timeline is Q2 2018. If needed, quite easy to integrate the native `<select>` element.
 
-| Notification | Notification | https://vaadin.com/elements/vaadin-notification/java-examples[Demo]
+| Notification | Notification | https://vaadin.com/components/vaadin-notification/java-examples[Demo]
 
 | Panel | - | Planned with `vaadin-card` element. No timeline yet. Also, it's possible to make any component scrollable with `component.getElement().getStyle().set("overflow", "auto")`
 
-| PasswordField | PasswordField | https://vaadin.com/elements/vaadin-text-field/java-examples[Demo]
+| PasswordField | PasswordField | https://vaadin.com/components/vaadin-text-field/java-examples[Demo]
 
 | PopupView | - | Not planned. You can use the `<vaadin-overlay>` element to create your own.
 
-| ProgressBar | ProgressBar | https://vaadin.com/elements/vaadin-progress-bar/java-examples[Demo]
+| ProgressBar | ProgressBar | https://vaadin.com/components/vaadin-progress-bar/java-examples[Demo]
 
-| RadioButtonGroup | RadioButtonGroup | https://vaadin.com/elements/vaadin-radio-button/java-examples[Demo]
+| RadioButtonGroup | RadioButtonGroup | https://vaadin.com/components/vaadin-radio-button/java-examples[Demo]
 
 | RichTextArea | - | Not planned. There are Web Components available, check https://vaadin.com/directory[vaadin.com/directory]
 
 | Slider | - | Not planned. There are Web Components available, check https://vaadin.com/directory[vaadin.com/directory]. If needed, quite easy to integrate the native `<input type=”range”>`
 
-| TabSheet | Tabs | https://vaadin.com/elements/vaadin-tabs/java-examples[Demo]
+| TabSheet | Tabs | https://vaadin.com/components/vaadin-tabs/java-examples[Demo]
 
-| TextArea | TextArea | https://vaadin.com/elements/vaadin-text-field/java-examples[Demo]
+| TextArea | TextArea | https://vaadin.com/components/vaadin-text-field/java-examples[Demo]
 
-| TextField | TextField | https://vaadin.com/elements/vaadin-text-field/java-examples[Demo]
+| TextField | TextField | https://vaadin.com/components/vaadin-text-field/java-examples[Demo]
 
 | Tree | - | Planned for 2018
 
@@ -97,19 +97,19 @@ The following table lists the existing Vaadin 8 components and their direct repl
 
 | Video | - | Not planned. Can directly use the native `<video>` element.
 
-| VerticalLayout | VerticalLayout | https://vaadin.com/elements/vaadin-ordered-layout/java-examples[Demo], more details <<#layouts,later in this chapter>>
+| VerticalLayout | VerticalLayout | https://vaadin.com/components/vaadin-ordered-layout/java-examples[Demo], more details <<#layouts,later in this chapter>>
 
-| VerticalSplitPanel | SplitLayout | https://vaadin.com/elements/vaadin-split-layout/java-examples[Demo]
+| VerticalSplitPanel | SplitLayout | https://vaadin.com/components/vaadin-split-layout/java-examples[Demo]
 
-| Upload | Upload | https://vaadin.com/elements/vaadin-upload/java-examples[Demo]
+| Upload | Upload | https://vaadin.com/components/vaadin-upload/java-examples[Demo]
 
-| Window | Dialog | https://vaadin.com/elements/vaadin-dialog/java-examples[Demo] Note that there is only limited support due to missing eg. minimize / maximize feature.
+| Window | Dialog | https://vaadin.com/components/vaadin-dialog/java-examples[Demo] Note that there is only limited support due to missing eg. minimize / maximize feature.
 
 |=========================================================
 
 For any missing components, you should first look for alternatives in https://vaadin.com/directory[vaadin.com/directory]. It shows both V10 add-ons with Java API and web components that can be integrated to Java.
 
-For the components that are available in V10, you can browse https://vaadin.com/elements/browse[vaadin.com/elements/browse] for the features and examples.
+For the components that are available in V10, you can browse https://vaadin.com/components/browse[vaadin.com/components/browse] for the features and examples.
 
 == Basic Component Features
 

--- a/theme/tutorial-built-in-themes.asciidoc
+++ b/theme/tutorial-built-in-themes.asciidoc
@@ -42,15 +42,15 @@ If the Theme annotation is not on a `@Route` Component or a top `RouterLayout` a
 
 = Creating your own component theme
 
-To create your own component theme to be used with the wrapped Vaadin Element components
+To create your own component theme to be used with the wrapped Vaadin components
 you need to create a theme class that informs flow how to translate the base un-themed
 component html import to use your themed version.
 
 The `getBaseUrl` should return the part of the htmlImport that can be used to determine if
-it is an import that could be changed to a theme import. (for Vaadin Elements that is `/src/`)
+it is an import that could be changed to a theme import. (for Vaadin components that is `/src/`)
 
 The `getThemeUrl` should return what the base url part should be changed to to get the
-correct theme import. (for Vaadin Elements that `/theme/[themeName]` is used)
+correct theme import. (for Vaadin components that `/theme/[themeName]` is used)
 
 [source,java]
 ----


### PR DESCRIPTION
Removed references to "Vaadin Elements" as the product name is not used anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/29)
<!-- Reviewable:end -->
