### PR TITLE
Introduce a proper theming chapter

### DIFF
--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -59,7 +59,11 @@ and keep the page state intact. The following tutorials explain how to use the R
 * <<importing-dependencies/tutorial-ways-of-importing#,Ways of importing the dependencies>>
 
 == Theming Applications
-* <<theme/tutorial-built-in-themes#,Component themes>>
+* <<theme/theming-overview#,Theming Overview>>
+* <<theme/using-component-themes#,Using Component Themes>>
+* <<theme/application-theming-basics#,Application Theming Basics>>
+* <<theme/theming-crash-course#,Theming Crash Course>>
+* <<theme/integrating-component-theme#,Integrating Your Own Component Theme>>
 
 == Creating Components
 * <<creating-components/tutorial-component-basic#,Creating A Simple Component Using the Element API>>

--- a/documentation/components/tutorial-flow-components-setup.asciidoc
+++ b/documentation/components/tutorial-flow-components-setup.asciidoc
@@ -65,7 +65,7 @@ properly configured to run with Polymer web components. Please refer to
 for more information.
 
 The platform also contains ready made _theming_ for the components that help you tweak and tune the look and feel of the components.
-See the <<../theme/tutorial-built-in-themes#,Component themes>> for more info.
+See the <<../theme/using-component-themes#,Using Component Themes>> for more info.
 
 For more ready-made Java APIs for Web Components, you should check the https://vaadin.com/directory/search?framework=Vaadin%2010[Vaadin Directory.]
 

--- a/documentation/migration/6-theming.asciidoc
+++ b/documentation/migration/6-theming.asciidoc
@@ -52,16 +52,16 @@ This should be applied on the root layout of the application.
 It can also be in an abstract class if you have multiple root layouts.
 
 Instead of a magic string, you need to provide a `Class` reference to an theme class that extends `AbstractTheme`.
-There are two premade themes available for V10: *Lumo* and *Material*. You should always use either of these themes,
-since the unthemed versions of the components are only meant as a baseline for creating a new theme from scratch!
+There is one ready-made theme available for V10: *Lumo*. Another theme, _Material_,
+is also in progress, but not yet available in V10. It will be possible to use it with the Vaadin components in 10 once it is released.
+You should always use a theme, since the unthemed versions of the components are only meant as a baseline for creating a new theme from scratch!
 
 The theme class will handle two things:
 
 * It tells Flow what theme it should use for the Vaadin Components and where the files can be found
 * It specifies a set of shared styles like fonts etc. that will be automatically loaded to the initial page by Flow for the theme.
 
-If you want to create your own reusable theme for Vaadin Components,
-you should read the <<../theme/tutorial-built-in-themes#,instructions>> on creating your own themes.
+The Lumo theme can be customized, see <<../theme/using-component-themes#,documentation>> for more information.
 
 === Application Theming
 

--- a/documentation/src/main/html/ThemingCrashCourse.html
+++ b/documentation/src/main/html/ThemingCrashCourse.html
@@ -1,0 +1,91 @@
+tutorial::theme/theming-crash-course.asciidoc
+<custom-style>
+    <style>
+        /* Example global style */
+        html {
+            font-size: 12pt;
+        }
+    </style>
+</custom-style>
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<dom-module id="my-view">
+    <template>
+        <style>
+            /* Example scoped styles, applied to <my-view> template contents only */
+
+            :host {
+                /* Styles for the `<my-view>` hosting element */
+                display: block;
+            }
+
+            .my-view-title {
+                font-weight: bold;
+                border-bottom: 1px solid gray;
+            }
+        </style>
+
+        <div class="my-view-title">My view title</div>
+    </template>
+</dom-module>
+<script>
+    class MyView extends Polymer.Element {
+        static get is() { return 'my-view'; }
+    }
+
+    customElements.define(MyView.is, MyView);
+</script>
+<custom-style>
+    <style>
+        html {
+            /* Example global custom CSS property definition */
+            --my-theme-color: brown;
+        }
+    </style>
+</custom-style>
+<!-- ... -->
+
+<dom-module id="my-view">
+    <template>
+        <style>
+            /* ... */
+
+            .my-view-title {
+                /* Example referencing custom CSS property */
+                color: var(--my-theme-color);
+            }
+        </style>
+    </template>
+
+    <!-- ... -->
+</dom-module>
+
+<dom-module id="shared-styles">
+    <template>
+        <style>
+            /* Example style module */
+            .my-outline-style {
+                outline: 1px solid green;
+            }
+        </style>
+    </template>
+</dom-module>
+
+<!-- ... -->
+<link rel="import" href="../styles/shared-styles.html">
+
+<dom-module id="my-view">
+    <template>
+        <style include="shared-styles">
+            /*  */
+        </style>
+    </template>
+
+    <!-- ... -->
+</dom-module>
+
+<link rel="import" href="./shared-styles.html">
+
+<custom-style>
+    <style include="shared-styles"></style>
+</custom-style>

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.tutorial.theme;
+
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.BodySize;
+import com.vaadin.flow.component.page.Viewport;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.tutorial.annotations.CodeFor;
+
+@CodeFor("theme/application-theming-basics.asciidoc")
+public class ApplicationTheme {
+
+    @HtmlImport("frontend://styles/shared-styles.html")
+    @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
+    @Theme(Lumo.class)
+    public class MainLayout extends Div implements RouterLayout {
+    }
+
+    private class Foo {
+        @BodySize(height = "100vh", width = "100vw")
+        @Theme(Lumo.class)
+        public class MainLayout extends Div implements RouterLayout {
+        }
+    }
+}

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ComponentTheme.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ComponentTheme.java
@@ -27,25 +27,8 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
-@CodeFor("theme/tutorial-built-in-themes.asciidoc")
+@CodeFor("theme/integrating-component-theme.asciidoc")
 public class ComponentTheme {
-
-    @Route(value = "")
-    @Theme(Lumo.class)
-    public class Application extends Div {
-    }
-
-    @Theme(Lumo.class)
-    public class MainLayout extends Div implements RouterLayout {
-    }
-
-    @Route(value = "", layout = MainLayout.class)
-    public class HomeView extends Div {
-    }
-
-    @Route(value = "blog", layout = MainLayout.class)
-    public class BlogPost extends Div {
-    }
 
     @HtmlImport("frontend://bower_components/vaadin-lumo-styles/color.html")
     public class MyTheme implements AbstractTheme {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ReadyMadeThemes.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ReadyMadeThemes.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.tutorial.theme;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.tutorial.annotations.CodeFor;
+
+@CodeFor("theme/using-component-themes.asciidoc")
+public class ReadyMadeThemes {
+    @Route(value = "")
+    @Theme(Lumo.class)
+    public class Application extends Div {
+    }
+
+    @Theme(Lumo.class)
+    public class MainLayout extends Div implements RouterLayout {
+    }
+
+    @Route(value = "", layout = MainLayout.class)
+    public class HomeView extends Div {
+    }
+
+    @Route(value = "blog", layout = MainLayout.class)
+    public class BlogPost extends Div {
+    }}

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/RootLayout.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/RootLayout.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.tutorial.theme;
+
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.InitialPageSettings;
+import com.vaadin.flow.server.PageConfigurator;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.tutorial.annotations.CodeFor;
+
+@CodeFor("theme/using-component-themes.asciidoc")
+@Theme(Lumo.class)
+public class RootLayout extends Div implements PageConfigurator, RouterLayout {
+
+    @Override
+    public void configurePage(InitialPageSettings settings) {
+        settings.getUi().getElement().setAttribute("theme", "dark");
+    }
+
+    @Override
+    public void showRouterLayoutContent(HasElement content) {
+
+    }
+
+}

--- a/documentation/src/test/java/com/vaadin/flow/tutorial/CodeFileChecker.java
+++ b/documentation/src/test/java/com/vaadin/flow/tutorial/CodeFileChecker.java
@@ -72,7 +72,7 @@ class CodeFileChecker implements TutorialLineChecker {
                                                 String line, int lineNumber) {
         if (!CODE_DECLARATION_LINE.equals(line)) {
             return Optional.of(String.format(
-                    "Tutorial %s L: has incorrect code block declaration: code block should be surrounded with '%s', got '%s' instead",
+                    "Tutorial %s L:%s has incorrect code block declaration: code block should be surrounded with '%s', got '%s' instead",
                     tutorialName, lineNumber, CODE_DECLARATION_LINE, line));
         }
         blockStarted = false;

--- a/documentation/theme/application-theming-basics.asciidoc
+++ b/documentation/theme/application-theming-basics.asciidoc
@@ -1,0 +1,59 @@
+---
+title: Application Theming Basics
+order: 3
+layout: page
+---
+
+= Application Theming Basics
+
+Application specific theming specifies styles that only effect one application.
+Whenever you have styles that are shared across multiple applications,
+you should make the theming as a separate module and resource that can be shared as a dependency for multiple applications.
+This chapter focuses only on theming a single application
+
+== Application Theme - What and Where ?
+
+The application can be themed with using pure CSS, but to be able to theme polymer web components,
+you should put the CSS in a HTML file. The recommended convention is to always put the application wide shared styles inside the
+`frontend` folder to subdirectory `styles` with the file name `shared-styles.html`,
+thus the full path should be `src/main/webapp/frontend/styles/shared-styles.html`.
+
+This file needs to be imported by using `@HtmlImport` annotation. For CSS files,
+the `@StyleSheet` annotation can be used.
+
+.Sample of a importing the application theme file
+[source,java]
+----
+@HtmlImport("frontend://styles/shared-styles.html")
+@Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
+@Theme(Lumo.class)
+public class MainLayout extends Div implements RouterLayout {
+}
+----
+
+The contents of the `shared-styles.html` are discussed further in <<theming-crash-course#,the next chapter's>>.
+The recommendation is that the file contains all the application global and view specific theming.
+
+For any HTML template based components, it is fine to have the styling, that only applies to the HTML in that template, inside that template file.
+This is because of the ease of development when you have just one HTML file when creating the HTML and CSS.
+And it also allows you to more easily make that template a stand-alone component that you can reuse and distribute to others,
+since the styling is already coupled to the component HTML and you don't have to look for it from elsewhere.
+There is an example on this in the crash course chapter too.
+
+== Styling the Body Element
+
+The `UI` component maps to the `body` element in DOM. By default, it does not have any theming applied to it.
+You can however easily customize from Java the sizing for it with the `BodySize` annotation.
+
+.The recommended UI sizing for most Flow applications to take full viewport available size
+[source,java]
+----
+@BodySize(height = "100vh", width = "100vw")
+@Theme(Lumo.class)
+public class MainLayout extends Div implements RouterLayout {
+}
+----
+
+[NOTE]
+If you don't apply some sizing to the `UI` / `body`, *you will not be able to use relative sizing* (% as unit) for any component,
+*unless the component has a parent that has defined size* using anything else than % as the unit.

--- a/documentation/theme/integrating-component-theme.asciidoc
+++ b/documentation/theme/integrating-component-theme.asciidoc
@@ -1,46 +1,10 @@
 ---
-title: Component themes
-order: 1
+title: Integrating Your Own Component Theme
+order: 5
 layout: page
 ---
 
-ifdef::env-github[:outfilesuffix: .asciidoc]
-
-= Component themes
-
-By default Flow imports components without any theme. To use themed components add `Theme` annotation to your navigation target with @Route (see below). You can also add `Theme` annotation to your root level RouterLayout.
-
-Each root `RouterLayout` can define it's own theme. This is not recommended though as any bootstrap addition may lead theme not to be used.
-
-.Sample setup for single view setup to get Lumo themed components
-[source,java]
-----
-@Route(value = "")
-@Theme(Lumo.class)
-public class Application extends Div {
-}
-----
-
-.Sample setup for multi navigation target application to get Lumo themed components
-[source,java]
-----
-@Theme(Lumo.class)
-public class MainLayout extends Div implements RouterLayout {
-}
-
-@Route(value = "", layout = MainLayout.class)
-public class HomeView extends Div {
-}
-
-@Route(value = "blog", layout = MainLayout.class)
-public class BlogPost extends Div {
-}
-----
-
-[NOTE]
-If the Theme annotation is not on a `@Route` Component or a top `RouterLayout` an exception will be thrown on startup.
-
-= Creating your own component theme
+= Integrating Your Own Component Theme
 
 To create your own component theme to be used with the wrapped Vaadin components
 you need to create a theme class that informs flow how to translate the base un-themed
@@ -97,3 +61,9 @@ Each of those html imports will be added to the BootstrapPage head.
 In the case where an exception navigation chain doesn't get the used `Theme` the
 exception navigation target can be annotated with `@NoTheme` so that
 a warning is not logged for missing theme.
+
+== Creating Your Own Component Theme
+
+The theming for the Vaadin components is built using `Vaadin.ThemableMixin`.
+See link:https://github.com/vaadin/vaadin-themable-mixin/wiki[vaadin-themable-mixin wiki] to learn how theming of Vaadin components is done.
+

--- a/documentation/theme/theming-crash-course.asciidoc
+++ b/documentation/theme/theming-crash-course.asciidoc
@@ -1,0 +1,186 @@
+---
+title: Theming Crash Course
+order: 4
+layout: page
+---
+= Theming Web Components
+
+This chapter gives an overview of everything you need to understand to master to be productive in theming modern web applications build with web components.
+
+First, it is important to draw the line between global styles and scoped styles:
+
+* Before web components were introduced, the styles were global on the web, meaning that a selector in CSS can target any element in the document.
+*  Web components, and Shadow DOM in particular, introduce style scoping to the web platform.
+The contents of web components are isolated from global styles, and instead have scoped styles, which are specific to a particular web component only.
+
+This guide describes how to apply global and scoped styles, as well as how to share common styles between style scopes for the application theming purpose.
+
+== Global Styles
+
+Global styles are styles defined in the document scope.
+Global styles can target document body and any regular DOM contents inside, including the application views,
+but can not target Shadow DOM contents, such as internals of Vaadin components, Polymer templates, and other web components.
+To define global styles, use `<custom-style><style>...</style><custom-style>` tags in HTML.
+
+[NOTE]
+Using the `<custom-style>` wrapper for global styles is required by Polymer to enable correct cross-browser scoping.
+
+Place your global styles in a separate HTML file:
+
+.src/main/webapp/frontend/styles/shared-styles.html
+[source,html]
+----
+<custom-style>
+  <style>
+    /* Example global style */
+    html {
+      font-size: 12pt;
+    }
+  </style>
+</custom-style>
+----
+
+As shown in the previous chapter, this file should be imported to the root layout level of your application.
+
+== Styling Polymer Templates
+
+Since Polymer templates are web components, their template contents end up in Shadow DOM.
+By design, Shadow DOM defines a local style scope, isolated from global styles.
+
+Scoped styles, which are specific to a single template, can be added directly to the `<style>` tag inside the template:
+
+.src/main/webapp/frontend/src/my-view.html
+[source,html]
+----
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<dom-module id="my-view">
+  <template>
+    <style>
+      /* Example scoped styles, applied to <my-view> template contents only */
+
+      :host {
+        /* Styles for the `<my-view>` hosting element */
+        display: block;
+      }
+
+      .my-view-title {
+        font-weight: bold;
+        border-bottom: 1px solid gray;
+      }
+    </style>
+
+    <div class="my-view-title">My view title</div>
+  </template>
+</dom-module>
+<script>
+  class MyView extends Polymer.Element {
+    static get is() { return 'my-view'; }
+  }
+
+  customElements.define(MyView.is, MyView);
+</script>
+----
+
+== Using Custom CSS Properties
+
+One of the needs for theming is to share common style values, such as sizes, colors, etc, between pieces of the application.
+This could be achieved using custom CSS properties, which is a special syntax for assigning and referencing CSS variables.
+Custom CSS properties are inherited, their values cross Shadow DOM boundaries.
+Polymer templates can reuse values defined by global styles, as well as override them.
+
+Use global styles for `html` element to define a global custom CSS property:
+
+.src/main/webapp/frontend/styles/shared-styles.html
+[source,html]
+----
+<custom-style>
+  <style>
+    html {
+      /* Example global custom CSS property definition */
+      --my-theme-color: brown;
+    }
+  </style>
+</custom-style>
+----
+
+For referencing your custom CSS property, use ```var(--my-property)``` syntax. For example, in your Polymer template styles:
+
+.src/main/webapp/frontend/src/my-view.html
+[source,html]
+----
+<!-- ... -->
+
+<dom-module id="my-view">
+  <template>
+    <style>
+      /* ... */
+
+      .my-view-title {
+        /* Example referencing custom CSS property */
+        color: var(--my-theme-color);
+      }
+    </style>
+  </template>
+
+  <!-- ... -->
+</dom-module>
+----
+
+== Using Style Modules
+
+Style modules allow sharing the same stylesheet between multiple Polymer templates and global styles.
+
+Style modules are defined in HTML using ```<dom-module id="my-styles"><template><style>/* ... */</style></template></dom-module>``` tag combination:
+
+.src/main/webapp/frontend/styles/shared-styles.html
+[source,html]
+----
+<dom-module id="shared-styles">
+  <template>
+    <style>
+      /* Example style module */
+      .my-outline-style {
+        outline: 1px solid green;
+      }
+    </style>
+  </template>
+</dom-module>
+----
+
+To include a style module in a Polymer template, import the module file with HTML imports and use ```<style include="module-id">```:
+
+.src/main/webapp/frontend/src/my-view.html
+[source,html]
+----
+<!-- ... -->
+<link rel="import" href="../styles/shared-styles.html">
+
+<dom-module id="my-view">
+  <template>
+    <style include="shared-styles">
+      /*  */
+    </style>
+  </template>
+
+  <!-- ... -->
+</dom-module>
+----
+
+NOTE: Use a space-separated list of style module ids to include multiple style modules into a single scope: ```<style include="shared-styles other-shared-styles"></style>```.
+
+Style modules can also be included in global styles:
+
+.src/main/webapp/frontend/styles/global-styles.html
+[source,html]
+----
+<link rel="import" href="./shared-styles.html">
+
+<custom-style>
+  <style include="shared-styles"></style>
+</custom-style>
+----
+
+WARNING: When included, each style module is duplicated in the target scope.
+Pay attention to the amount of styles shared through style modules.
+To avoid unnecessary overhead, it is best to minimize the amount of shared styles in your application.

--- a/documentation/theme/theming-overview.asciidoc
+++ b/documentation/theme/theming-overview.asciidoc
@@ -1,0 +1,21 @@
+---
+title: Theming
+order: 1
+layout: page
+---
+
+# Theming Overview
+
+Vaadin separates the appearance of the user interface from its logic using _themes_.
+Theming is the activity that is done when the look and feel of the UI components or application is customized.
+Theming is done as with any HTML content by using cascading style sheets or in short https://www.w3.org/Style/CSS/[CSS] to it.
+This documentation does not cover the basics of CSS, for more resources see for example the Open Directory Project https://dmoztools.net/Computers/Data_Formats/Style_Sheets/CSS/[CSS guides].
+
+Theming can be split into the following concepts:
+
+* Application theming - creating global styles for one application and its views
+* Component theming - creating styling for reusable components to use and further customize in any application
+
+This documentation first explains how you can use and customize the ready-made component themes provided by Vaadin.
+Then it describes the how to theme applications.
+Finally there is instructions for creating your own component theme and providing the Flow integration for it.

--- a/documentation/theme/using-component-themes.asciidoc
+++ b/documentation/theme/using-component-themes.asciidoc
@@ -1,0 +1,90 @@
+---
+title: Using Component Themes
+order: 2
+layout: page
+---
+
+ifdef::env-github[:outfilesuffix: .asciidoc]
+
+= Using Component Themes
+
+By default Flow imports Vaadin's components without any theme,
+but you actually never want to use the components without a theme.
+To use any of the ready-made component themes, just add `Theme` annotation to your root navigation level,
+`RouterLayout` or to the top level @Route (see below).
+
+Each root `RouterLayout` can define it's own theme. This is not recommended though as any bootstrap addition can cause theme not to be used.
+*We don't support nor recommend mixing different themes together* - the UX should be consistent in one application.
+
+.Sample setup for application with navigation hierarchy to get Lumo themed Vaadin components
+[source,java]
+----
+@Theme(Lumo.class)
+public class MainLayout extends Div implements RouterLayout {
+}
+
+@Route(value = "", layout = MainLayout.class)
+public class HomeView extends Div {
+}
+
+@Route(value = "blog", layout = MainLayout.class)
+public class BlogPost extends Div {
+}
+----
+
+.Sample setup for single view setup to get Lumo themed components
+[source,java]
+----
+@Route(value = "")
+@Theme(Lumo.class)
+public class Application extends Div {
+}
+----
+
+The theme class automatically handles two things:
+
+* It tells Flow what theme it should use for the Vaadin Components and where the files can be found
+* It specifies a set of shared styles like fonts etc. that will be automatically loaded to the initial page by Flow for the theme.
+
+[NOTE]
+If the Theme annotation is not on a `@Route` Component or a top `RouterLayout` an exception will be thrown on startup.
+
+== Available Themes and Customizations
+
+In Vaadin 10 there is only one ready-made component theme, _Lumo_, which is the main theme for all Vaadin components.
+It gives you a full set of building blocks to build a modern looking web application that works just as well on desktop and on mobile.
+
+The Flow integration for Lumo is a part of the `vaadin-core` dependency, and as shown in the previous chapter,
+very easily taken into use. When using `@Theme(Lumo.class)`, you don't need to add any resource imports manually.
+
+Lumo provides some customization points for the components, that allow you to very fine tune the look and provide better UX.
+It can be customized by using CSS custom properties, see link:https://vaadin.com/themes/lumo[the Lumo documentation] for more information.
+The theming for the Vaadin components is built using `Vaadin.ThemableMixin`.
+See link:https://github.com/vaadin/vaadin-themable-mixin/wiki[vaadin-themable-mixin wiki] to learn how theming of Vaadin components is done.
+
+[NOTE]
+There is another theme being build, _Material Theme_. Once it is ready enough, a Flow integration will be available.
+Even though it will not be part of Vaadin 10, you should be able to use it with all Vaadin 10 components.
+You can take a look at it and start using it already by manually importing the webjar and the dependencies.
+See the link:https://vaadin.com/themes/material[Material Theme documentation] for more information and tracking progress.
+
+=== Using Lumo variants
+
+Lumo comes with a dark variant. For taking it to use, you need to apply the `theme="dark"` attribute to the DOM.
+Usually you want to do it for the whole UI, thus you should apply it to the `<body>` element.
+
+.Using the dark variant of Lumo
+[source,java]
+----
+public class RootLayout extends Div implements PageConfigurator, RouterLayout {
+
+    @Override
+    public void configurePage(InitialPageSettings settings) {
+        settings.getUi().getElement().setAttribute("theme", "dark");
+    }
+}
+----
+
+Individual components have also variants available.
+Component variants are applied similarly using the element API to set the variant as the `theme` attribute.
+For looking up available component variants, https://vaadin.com/components/browse[see the component HTML examples] and look under the _Lumo Theme_ tab for examples of the variants.


### PR DESCRIPTION
Splits existing component theming docs into using ready-made themes and integrating a component theme.
Adds documentation on application theming basics and theming web components.

Fixes https://github.com/vaadin/flow/issues/3347
Fixes https://github.com/vaadin/flow/issues/3042

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/49)
<!-- Reviewable:end -->
