### PR TITLE
Update docs after making body full sized by default

### DIFF
--- a/documentation/advanced/tutorial-bootstrap.asciidoc
+++ b/documentation/advanced/tutorial-bootstrap.asciidoc
@@ -173,9 +173,7 @@ a `PREPEND` then the `@BodySize` will be the deciding one.
 If the `BodySize` annotation is not on a `@Route` Component or a top `RouterLayout` an exception will be thrown on startup.
 
 [NOTE]
-It is recommended to use the default body size. If you don't apply any sizing to the `UI` / `body`,
-*you will not be able to use relative sizing* (% as unit) for any component,
-*unless the component has a parent that has defined size* using anything else than % as the unit.
+When using an empty `@BodySize` annotation (which doesn't apply any sizing for the UI / body), you will not be able to use relative sizing (% as unit) for any component, unless the component has a parent that has defined size using anything else than % as the unit. For that reason, it is recommended to use the default settings for the body size, by omitting the `@BodySize` annotation, or to declare a specific size for it.
 
 == BootstrapListener
 

--- a/documentation/advanced/tutorial-bootstrap.asciidoc
+++ b/documentation/advanced/tutorial-bootstrap.asciidoc
@@ -132,20 +132,22 @@ If the PageConfigurator implementation is not on a `@Route` Component or a `Rout
 
 == Setting the body size styles
 
-To set the body size style you can either use the `@BodySize` annotation or the `PageConfigurator`.
+By default, the body element in a Flow application has size properties `height = "100vh", width = "100vw"`,
+which makes the page fill the entire viewport.
+To change the width and height properties of the body you can either use the `@BodySize` annotation or the `PageConfigurator`.
 
 For `@BodySize` you just add it to the the navigation target with `@Route` or
 the top most `RouterLayout` that builds the navigation target chain.
+You can pass custom height and width properties for the annotation, or leave them out
+to just prevent the default size to be applied for the body:
 
 [source,java]
 ----
 @Route("")
-@BodySize(height = "100vh", width = "100vw")
+@BodySize
 public static class BodySizeAnnotatedRoute extends Div {
 }
 ----
-
-You can define height and width or just one of them as wanted.
 
 With the `PageConfigurator` you can just addInlineContent like:
 
@@ -171,7 +173,7 @@ a `PREPEND` then the `@BodySize` will be the deciding one.
 If the `BodySize` annotation is not on a `@Route` Component or a top `RouterLayout` an exception will be thrown on startup.
 
 [NOTE]
-It is recommended that the body sizes be set to `height = 100vh, width = 100vw`
+It is recommended to use the default body size, to make sure that components with relative sizes work as expected.
 
 == BootstrapListener
 

--- a/documentation/advanced/tutorial-bootstrap.asciidoc
+++ b/documentation/advanced/tutorial-bootstrap.asciidoc
@@ -173,7 +173,9 @@ a `PREPEND` then the `@BodySize` will be the deciding one.
 If the `BodySize` annotation is not on a `@Route` Component or a top `RouterLayout` an exception will be thrown on startup.
 
 [NOTE]
-It is recommended to use the default body size, to make sure that components with relative sizes work as expected.
+It is recommended to use the default body size. If you don't apply any sizing to the `UI` / `body`,
+*you will not be able to use relative sizing* (% as unit) for any component,
+*unless the component has a parent that has defined size* using anything else than % as the unit.
 
 == BootstrapListener
 

--- a/documentation/introduction/tutorial-get-started.asciidoc
+++ b/documentation/introduction/tutorial-get-started.asciidoc
@@ -141,7 +141,6 @@ The Java code of the application stub main view can be found in the
 
 [source,java]
 ----
-@BodySize(height = "100vh", width = "100vw")
 @HtmlImport("styles/shared-styles.html")
 @Route("")
 @Theme(Lumo.class)
@@ -175,9 +174,6 @@ components. Layouts are used to position and display other components.
 The third annotation, [classname]#@Theme(Lumo.class)#, defines the component theme to use.
 Using this annotation on the root level navigation target or root layout will enable the Lumo theme
 for all used Vaadin components automatically. You can read more about Web Component themes and Lumo from https://vaadin.com/themes.
-
-Finally, the third annotation [classname]#@BodySize(height = "100vh", width = "100vw")#
-defines the _styles_ that are set to the `<body>` element to make it resize nicely on all devices.
 
 In the main view we have a template (more on it in a bit) that shows
 some text, and a button that, when clicked, modifies the value displayed by the
@@ -358,7 +354,6 @@ likely want to refer to it later. Also, let us get a reference to our
 @HtmlImport("styles/shared-styles.html")
 @Route("")
 @Theme(Lumo.class)
-@BodySize(height = "100vh", width = "100vw")
 public class MainView extends VerticalLayout {
     // Add the next two lines:
     private CustomerService service = CustomerService.getInstance();

--- a/documentation/migration/6-theming.asciidoc
+++ b/documentation/migration/6-theming.asciidoc
@@ -33,8 +33,6 @@ The following example shows all the tricks for theming applications, covered in 
 ----
 @Theme(Lumo.class) // the theme for Vaadin Components
 @HtmlImport("frontend://styles/shared-styles.html") // the application specific theme
-@BodySize(height = "100vh", width = "100vw") // styles the <body> for 100 % available viewport
-// viewport definition
 @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
 public class MainLayout extends Div implements RouterLayout,
         AfterNavigationObserver, PageConfigurator {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/advanced/BootstrapPage.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/advanced/BootstrapPage.java
@@ -147,7 +147,7 @@ public class BootstrapPage {
 
 
     @Route("")
-    @BodySize(height = "100vh", width = "100vw")
+    @BodySize
     public static class BodySizeAnnotatedRoute extends Div {
     }
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/gettingstarted/MainView.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/gettingstarted/MainView.java
@@ -15,7 +15,6 @@ import com.vaadin.flow.theme.lumo.Lumo;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("introduction/tutorial-get-started.asciidoc")
-@BodySize(height = "100vh", width = "100vw")
 @HtmlImport("styles/shared-styles.html")
 @Route("")
 @Theme(Lumo.class)

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/gettingstarted/MainView.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/gettingstarted/MainView.java
@@ -8,7 +8,6 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/migration/Theming.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/migration/Theming.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.tutorial.migration;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/migration/Theming.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/migration/Theming.java
@@ -17,8 +17,6 @@ import com.vaadin.flow.tutorial.annotations.CodeFor;
 public class Theming {
     @Theme(Lumo.class) // the theme for Vaadin Components
     @HtmlImport("frontend://styles/shared-styles.html") // the application specific theme
-    @BodySize(height = "100vh", width = "100vw") // styles the <body> for 100 % available viewport
-// viewport definition
     @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
     public class MainLayout extends Div implements RouterLayout,
             AfterNavigationObserver, PageConfigurator {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.tutorial.theme;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.theme.Theme;

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/theme/ApplicationTheme.java
@@ -18,10 +18,4 @@ public class ApplicationTheme {
     public class MainLayout extends Div implements RouterLayout {
     }
 
-    private class Foo {
-        @BodySize(height = "100vh", width = "100vw")
-        @Theme(Lumo.class)
-        public class MainLayout extends Div implements RouterLayout {
-        }
-    }
 }

--- a/documentation/theme/application-theming-basics.asciidoc
+++ b/documentation/theme/application-theming-basics.asciidoc
@@ -39,21 +39,3 @@ This is because of the ease of development when you have just one HTML file when
 And it also allows you to more easily make that template a stand-alone component that you can reuse and distribute to others,
 since the styling is already coupled to the component HTML and you don't have to look for it from elsewhere.
 There is an example on this in the crash course chapter too.
-
-== Styling the Body Element
-
-The `UI` component maps to the `body` element in DOM. By default, it does not have any theming applied to it.
-You can however easily customize from Java the sizing for it with the `BodySize` annotation.
-
-.The recommended UI sizing for most Flow applications to take full viewport available size
-[source,java]
-----
-@BodySize(height = "100vh", width = "100vw")
-@Theme(Lumo.class)
-public class MainLayout extends Div implements RouterLayout {
-}
-----
-
-[NOTE]
-If you don't apply some sizing to the `UI` / `body`, *you will not be able to use relative sizing* (% as unit) for any component,
-*unless the component has a parent that has defined size* using anything else than % as the unit.

--- a/tutorial-getting-started/src/main/java/com/vaadin/flow/demo/helloworld/MainView.java
+++ b/tutorial-getting-started/src/main/java/com/vaadin/flow/demo/helloworld/MainView.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcons;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
@@ -34,7 +33,6 @@ import com.vaadin.flow.tutorial.annotations.CodeFor;
 /**
  * The main view contains a button and a template element.
  */
-@BodySize(height = "100vh", width = "100vw")
 @HtmlImport("styles/shared-styles.html")
 @Route("")
 @Theme(Lumo.class)


### PR DESCRIPTION
After https://github.com/vaadin/flow/pull/3821 `@BodySize(height = "100vh", width = "100vw")` is the default and the annotation is often not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/60)
<!-- Reviewable:end -->
