### PR TITLE
Do not use Label when not labeling input fields

### DIFF
--- a/documentation/components/tutorial-component-basic-features.asciidoc
+++ b/documentation/components/tutorial-component-basic-features.asciidoc
@@ -36,7 +36,7 @@ Example:
 
 [source,java]
 ----
-Label label = new Label("My label");
+Span label = new Span("My label");
 label.setVisible(false);
 // this is not transmitted to the client side
 label.setText("Changed my label");
@@ -61,7 +61,7 @@ Example:
 
 [source,java]
 ----
-Label label = new Label("My label");
+Span label = new Span("My label");
 label.setVisible(false);
 
 Div container = new Div();

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/components/ComponentBasicFeatures.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/components/ComponentBasicFeatures.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.polymertemplate.Id;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
@@ -31,7 +31,7 @@ public class ComponentBasicFeatures {
     private Component mappedComponent;
 
     public void visibility() {
-        Label label = new Label("My label");
+        Span label = new Span("My label");
         label.setVisible(false);
         // this is not transmitted to the client side
         label.setText("Changed my label");
@@ -58,7 +58,7 @@ public class ComponentBasicFeatures {
     }
 
     public void id() {
-        Label component = new Label();
+        Span component = new Span();
         component.setId("my-component");
     }
 


### PR DESCRIPTION
Label should only be used when labeling input fields.
See
https://github.com/vaadin/flow/issues/3532
https://github.com/vaadin/flow-and-components-documentation/issues/37
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/65)
<!-- Reviewable:end -->
