### PR TITLE
Fixes after introduce fluent API for configuring DOM listeners

### DIFF
--- a/documentation/components/tutorial-enabled-state.asciidoc
+++ b/documentation/components/tutorial-enabled-state.asciidoc
@@ -183,8 +183,8 @@ To unblock DOM event for a disabled element using API method you may use
 ----
 public Notification() {
     getElement().addEventListener("opened-changed", event -> {
-        System.out.println("Notification is opened");
-    }, DisabledUpdateMode.ALWAYS);
+       System.out.println("Notification is opened");})
+    .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
 }
 ----
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/components/DisabledComponents.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/components/DisabledComponents.java
@@ -41,11 +41,11 @@ public class DisabledComponents extends Component {
 
         public Notification() {
             getElement().addEventListener("opened-changed", event -> {
-                System.out.println("Notification is opened");
-            }, DisabledUpdateMode.ALWAYS);
+                System.out.println("Notification is opened");})
+            .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
         }
     }
-
+    
     @DomEvent(value = "click", allowUpdates = DisabledUpdateMode.ALWAYS)
     public class CustomEvent extends ComponentEvent<Component> {
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/components/DisabledComponents.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/components/DisabledComponents.java
@@ -45,7 +45,7 @@ public class DisabledComponents extends Component {
             .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
         }
     }
-    
+
     @DomEvent(value = "click", allowUpdates = DisabledUpdateMode.ALWAYS)
     public class CustomEvent extends ComponentEvent<Component> {
 


### PR DESCRIPTION
Original issue vaadin/flow#3885

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/76)
<!-- Reviewable:end -->
