### PR TITLE
Link to release notes instead of listing missing features

### DIFF
--- a/documentation/migration/7-tools-integrations.asciidoc
+++ b/documentation/migration/7-tools-integrations.asciidoc
@@ -45,6 +45,8 @@ and allow using encapsulated CSS, HTML, Web Components and JavaScript. Using thi
 First, any template can be rendered inside one another. And as templates are themselves Web Components,
 custom components are fully supported by the new Designer as well. On the other hand, HTML as a syntax is flexible enough that Designer might not work with templates created in other ways.
 
+Some features of Designer are only available for Vaadin 10 and other features can only be used when editing Vaadin 8 layouts. See the https://github.com/vaadin/designer/blob/master/RELEASE-NOTES.md[Release Notes] for an overview of the feature-level differences.
+
 === Migrating from Vaadin 8 Designs
 
 As the underlying technology has been completely changed, Vaadin 8 Designs are not compatible with Flow applications.
@@ -55,14 +57,6 @@ and then modified to fit the new element API's.
 === Version Support
 
 The new Designer plugin will support editing both Vaadin 8 and Vaadin 10 designs. Regardless whether you are working with Vaadin 8 or Vaadin 10, you should always update to the latest version of Designer to receive the latest bugfixes and enhancements.
-
-=== Missing Features
-
-* Pre-made templates. The wizard currently only allows creating blank designs.
-* Configuring themes or style imports. Lumo & default style module is always loaded.
-* Editing alignment or size via the popup infobar. Alignment and size can be configured through CSS.
-* Custom property editors, for example for date or icon type properties. Only strings and booleans are supported.
-* Replace- and wrap-with.
 
 == Vaadin TestBench
 


### PR DESCRIPTION
The list of missing features is easily outdated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/143)
<!-- Reviewable:end -->
