### PR TITLE
Use correct spring package

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -50,8 +50,8 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-spring-addon</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>vaadin-spring</artifactId>
+            <version>10.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Flow-spring-addon has been moved outside of flow. 
This should be picked up to V10 branch also

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/205)
<!-- Reviewable:end -->
