### PR TITLE
Initialization of components using autowiring

### DIFF
--- a/documentation/spring/tutorial-spring-routing.asciidoc
+++ b/documentation/spring/tutorial-spring-routing.asciidoc
@@ -28,7 +28,8 @@ tutorial and other router tutorials for more details about using router.
 The only thing that is new here for Spring is the possibility to use dependency injection in the
 components annotated with `@Route`. Such a component is instantiated by Spring
 and becomes a Spring initialized bean. In particular it means that you may autowire
-other Spring managed beans. Here is an example:
+other Spring managed beans. Use constructor-based autowiring or field-based autowiring
+with `@PostConstruct` method. Here is an example:
 
 [source,java]
 ----
@@ -38,7 +39,8 @@ public class RootComponent extends Div {
     @Autowired
     private DataBean dataBean;
     
-    public RootComponent(){
+    @PostConstruct
+    public void init() {
         setText(dataBean.getMessage());
     }
 }


### PR DESCRIPTION
When using field-based @Autowired beans in constructor a NullPointerException will arise at runtime. You can use either @PostConstruct method for initialization or switch to constructor-based autowiring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/217)
<!-- Reviewable:end -->
