### PR TITLE
Add reference to production setting in template tutorial

### DIFF
--- a/documentation/polymer-templates/tutorial-template-basic.asciidoc
+++ b/documentation/polymer-templates/tutorial-template-basic.asciidoc
@@ -234,4 +234,4 @@ layout.add(hello);
 ----
 
 [NOTE]
-To Make your template-based product supporting non-ES6 browers like IE 11 and Safari 9, you need to configure the `vaadin-maven-plugin` in your `pom.xml`. Click https://github.com/vaadin/flow-and-components-documentation/blob/master/documentation/production/tutorial-production-mode-basic.asciidoc[Taking your Application into Production] for more information.
+To make your template-based product supporting non-ES6 browers like IE 11 and Safari 9, you need to configure the `vaadin-maven-plugin` in your `pom.xml`. See the chapter https://github.com/vaadin/flow-and-components-documentation/blob/master/documentation/production/tutorial-production-mode-basic.asciidoc[Taking your Application into Production] for more information.

--- a/documentation/polymer-templates/tutorial-template-basic.asciidoc
+++ b/documentation/polymer-templates/tutorial-template-basic.asciidoc
@@ -232,3 +232,6 @@ HelloWorld hello = new HelloWorld();
 Div layout = new Div();
 layout.add(hello);
 ----
+
+[NOTE]
+To Make your template-based product supporting non-ES6 browers like IE 11 and Safari 9, you need to configure the `vaadin-maven-plugin` in your `pom.xml`. Click https://github.com/vaadin/flow-and-components-documentation/blob/master/documentation/production/tutorial-production-mode-basic.asciidoc[Taking your Application into Production] for more information.

--- a/documentation/production/tutorial-production-mode-advanced.asciidoc
+++ b/documentation/production/tutorial-production-mode-advanced.asciidoc
@@ -20,7 +20,7 @@ To fix this you have a couple choices:
  - Use the defined profile from <<tutorial-production-mode-basic#,Basic production mode>>, with the jetty plugin.
  - running the application with `mvn jetty:run-exploded` or `mvn jetty:run-war`
  - disable production mode using the servlet parameter `original.frontend.resources=true`
- - compile the frontend resources by adding the `flow-maven-plugin` see: <<tutorial-production-mode-basic#,Basic production mode>>
+ - compile the frontend resources by adding the `vaadin-maven-plugin` see: <<tutorial-production-mode-basic#,Basic production mode>>
  - remove the `flow-server-production-mode` dependency
 
 == Plugin goals and goal parameters
@@ -132,4 +132,3 @@ and with all `$$*.css$$`, `$$*.js$$` and `$$*.html$$` additionally optimized for
 * If not configured to be skipped, `transpileOutputDirectory/es5OutputDirectoryName` with all files from `transpileEs6SourceDirectory` copied into it
 and with all `$$*.css$$`, `$$*.js$$` and `$$*.html$$` additionally optimized for production usage AND transpiled into ES5 so that old browsers are able to use the application still
 * `transpileWorkingDirectory` with all frontend tools and additional files created for the tools, can be ignored after the process
-

--- a/documentation/production/tutorial-production-mode-basic.asciidoc
+++ b/documentation/production/tutorial-production-mode-basic.asciidoc
@@ -20,11 +20,6 @@ and then create a production mode profile:
     <profile>
         <id>production</id>
 
-        <properties>
-            //This version should have been defined in the previous project settings
-            <vaadin.version>[CURRENT_PLATFORM_VERSION]</vaadin.version>
-        </properties>
-
         <dependencies>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/documentation/production/tutorial-production-mode-basic.asciidoc
+++ b/documentation/production/tutorial-production-mode-basic.asciidoc
@@ -10,7 +10,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 == Simple steps for production mode build
 
-To get your application prepped for production you want to add the `flow-maven-plugin` into the pom.xml
+To get your application prepped for production you want to add the `vaadin-maven-plugin` into the pom.xml
 and then create a production mode profile:
 
 .pom.xml
@@ -21,7 +21,8 @@ and then create a production mode profile:
         <id>production</id>
 
         <properties>
-            <flow.maven.plugin.version>[PLATFORM_COMPATIBLE_VERSION_HERE]</flow.maven.plugin.version>
+            //This version should have been defined in the previous project settings
+            <vaadin.version>[CURRENT_PLATFORM_VERSION]</vaadin.version>
         </properties>
 
         <dependencies>
@@ -35,8 +36,8 @@ and then create a production mode profile:
             <plugins>
                 <plugin>
                     <groupId>com.vaadin</groupId>
-                    <artifactId>flow-maven-plugin</artifactId>
-                    <version>${flow.maven.plugin.version}</version>
+                    <artifactId>vaadin-maven-plugin</artifactId>
+                    <version>${vaadin.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -56,7 +57,7 @@ The profile is recommended so that you don't get any unexpected problems due to
 production settings when running in development mode.
 
 [NOTE]
-The `flow.maven.plugin.version` should be a version that is compatible with the used platform.
+For users who use `flow` only, you can use `flow-maven-plugin` as artifactId and matching the version number with current flow version
 
 After this all that is needed is to run `mvn clean package -Pproduction`.
 This will then do transpilation, minimisation and bundling on the application resources and build a production ready war.
@@ -85,7 +86,7 @@ With this the server can be started with `mvn jetty:run -Pproduction`.
 [NOTE]
 *transpilation.output* should by default be `${project.build.directory}/${project.build.finalName}/`.
 
-When not using the default *transpilation.output* target the `flow-maven-plugin` will require the configuration:
+When not using the default *transpilation.output* target the `vaadin-maven-plugin` will require the configuration:
 
 [source, xml]
 ----

--- a/documentation/production/tutorial-production-mode-basic.asciidoc
+++ b/documentation/production/tutorial-production-mode-basic.asciidoc
@@ -57,7 +57,7 @@ The profile is recommended so that you don't get any unexpected problems due to
 production settings when running in development mode.
 
 [NOTE]
-For users who use `flow` only, you can use `flow-maven-plugin` as artifactId and matching the version number with current flow version
+For users who use `flow` only, you can use `flow-maven-plugin` as artifactId and match the version number with current flow version
 
 After this all that is needed is to run `mvn clean package -Pproduction`.
 This will then do transpilation, minimisation and bundling on the application resources and build a production ready war.

--- a/documentation/production/tutorial-production-mode-customising.asciidoc
+++ b/documentation/production/tutorial-production-mode-customising.asciidoc
@@ -50,8 +50,8 @@ Each fragment should have its name and at least one file specified.
 ----
 <plugin>
     <groupId>com.vaadin</groupId>
-    <artifactId>flow-maven-plugin</artifactId>
-    <version>${flow.maven.plugin.version}</version>
+    <artifactId>vaadin-maven-plugin</artifactId>
+    <version>${vaadin.version}</version>
     <executions>
         <execution>
             <goals>
@@ -139,8 +139,8 @@ You still have to configure Maven plugin if the json file is not in the default 
 ----
 <plugin>
     <groupId>com.vaadin</groupId>
-    <artifactId>flow-maven-plugin</artifactId>
-    <version>${flow.maven.plugin.version}</version>
+    <artifactId>vaadin-maven-plugin</artifactId>
+    <version>${vaadin.version}</version>
     <executions>
         <execution>
             <goals>

--- a/tutorial-getting-started/pom.xml
+++ b/tutorial-getting-started/pom.xml
@@ -127,8 +127,8 @@
                 <plugins>
                     <plugin>
                         <groupId>com.vaadin</groupId>
-                        <artifactId>flow-maven-plugin</artifactId>
-                        <version>${flow.maven.plugin.version}</version>
+                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <version>${vaadin.version}</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
Using `vaadin-maven-plugin` instead of `flow-maven-plugin`, add NOTE for flow-only users

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/221)
<!-- Reviewable:end -->
