### PR TITLE
Correct Autowired bean usage with CTOR (#229)

### DIFF
--- a/documentation/spring/tutorial-spring-routing.asciidoc
+++ b/documentation/spring/tutorial-spring-routing.asciidoc
@@ -35,10 +35,7 @@ other Spring managed beans. Here is an example:
 @Route("")
 public class RootComponent extends Div {
     
-    @Autowired
-    private DataBean dataBean;
-    
-    public RootComponent(){
+    public RootComponent(@Autowired DataBean dataBean){
         setText(dataBean.getMessage());
     }
 }

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/spring/SpringRouting.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/spring/SpringRouting.java
@@ -28,11 +28,11 @@ public class SpringRouting {
     @Route("")
     public class RootComponent extends Div {
 
-        @Autowired
-        private DataBean dataBean;
-
         public RootComponent() {
             setText("Default path");
+        }
+
+        public RootComponent(@Autowired DataBean dataBean) {
             setText(dataBean.getMessage());
         }
     }


### PR DESCRIPTION
Fix for #228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/230)
<!-- Reviewable:end -->
