### PR TITLE
Change docs link to our own content (#254)

### DIFF
--- a/documentation/web-components/integrating-a-web-component.asciidoc
+++ b/documentation/web-components/integrating-a-web-component.asciidoc
@@ -6,7 +6,7 @@ layout: page
 
 = Integrating a Web Component
 
-Web components is a standards based way to create and consume reusable components through custom HTML tags. To learn more about web componnents, see https://www.webcomponents.org/introduction.
+Web Components are a collection of web standards allowing you to create new HTML tags with custom name, reusability and full encapsulation on styles & markup. To understand more about what Web Components are, visit https://github.com/vaadin/flow-and-components-documentation/blob/master/documentation/web-components/introduction-to-webcomponents.asciidoc[Introduction to Web Components].
 
 To be able to use a web component from Flow you need two things: to load the HTML/JS/CSS files needed by the component and a Java API used to configure the component and to listen to events from it.
 


### PR DESCRIPTION
* Change docs link

I changed Web Components introduction link from webcomponents.org to our own one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/264)
<!-- Reviewable:end -->
