### PR TITLE
Fix missing whitespace in osgi docs

### DIFF
--- a/documentation/osgi/tutorial-osgi-basic.asciidoc
+++ b/documentation/osgi/tutorial-osgi-basic.asciidoc
@@ -26,6 +26,7 @@ The easiest way to convert regular maven-based Vaadin application into a valid O
     <packaging>jar</packaging>
 ----
 * Change the scope for all vaadin dependencies from default to `provided`, like this:
+
 [source, xml]
 ----
     <dependency>
@@ -35,6 +36,7 @@ The easiest way to convert regular maven-based Vaadin application into a valid O
     </dependency>
 ----
 * Add OSGi-related dependencies to the project
+
 [source, xml]
 ----
     <groupId>com.vaadin</groupId>
@@ -62,6 +64,7 @@ The easiest way to convert regular maven-based Vaadin application into a valid O
     </dependency>
 ----
 * Setup necessary plugins for building the project:
+
 [source, xml]
 ----
  <build>
@@ -93,6 +96,7 @@ The easiest way to convert regular maven-based Vaadin application into a valid O
 </build>
 ----
 * Add bundle script (`bnd.bnd`) into the project root folder:
+
 [source, text]
 ----
 Bundle-Name: ${project.name}


### PR DESCRIPTION
Due to an asciidoc bug (?) the XML code snippets were broken in vaadin.com/docs

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/365)
<!-- Reviewable:end -->
