### PR TITLE
Fix parentprefix -> routeprefix

### DIFF
--- a/documentation/routing/tutorial-router-layout.asciidoc
+++ b/documentation/routing/tutorial-router-layout.asciidoc
@@ -96,9 +96,9 @@ previously mentioned `SomePathComponent`
 === Absolute routes
 
 Sometimes we might have a setup where we want to use the same parent components in many parts,
-but in some cases not use any `@ParentPrefix` from the parent chain or only use them for a defined part.
+but in some cases not use any `@RoutePrefix` from the parent chain or only use them for a defined part.
 
-In these cases we can add `absolute = true` to either the `@Route` or `@ParentPrefix` annotations.
+In these cases we can add `absolute = true` to either the `@Route` or `@RoutePrefix` annotations.
 
 So if we have something that we want to use in many places in the `SomeParent` layout, but
 do not want to get the route prefix added to our navigation path we could have a class `MyContent`


### PR DESCRIPTION
Should be backported to v10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/376)
<!-- Reviewable:end -->
