### PR TITLE
Remove mention of direct HTML support

### DIFF
--- a/documentation/components/tutorial-flow-grid.asciidoc
+++ b/documentation/components/tutorial-flow-grid.asciidoc
@@ -10,7 +10,7 @@ layout: page
 
 `Grid` is for displaying and editing tabular data laid out in rows
 and columns. At the top, a __header__ can be shown, and a __footer__ at the
-bottom. In addition to plain text, the header and footer can contain HTML and
+bottom. In addition to plain text, the header and footer can contain
 components. Having components in the header allows implementing filtering
 easily. The grid data can be sorted by clicking on a column header;
 shift-clicking a column header enables secondary sorting criteria.

--- a/documentation/components/tutorial-flow-grid.asciidoc
+++ b/documentation/components/tutorial-flow-grid.asciidoc
@@ -246,11 +246,11 @@ Template renderers are covered later in this tutorial.
 nameColumn.setHeader("Name");
 // Sets a header containing a custom template,
 // in this case simply bolding the caption "Name"
-nameColumn.setHeader("<b>Name</b>");
+nameColumn.setHeader(new Html("<b>Name</b>"));
 
 // Similarly for the footer
 nameColumn.setFooter("Name");
-nameColumn.setFooter("<b>Name</b>");
+nameColumn.setFooter(new Html("<b>Name</b>"));
 ----
 
 === Column Order


### PR DESCRIPTION
Headers don't support HTML markup directly like in V8. Use a `Html` component to put HTML in headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/421)
<!-- Reviewable:end -->
