### PR TITLE
Remove mention of direct HTML support

### DIFF
--- a/documentation/components/tutorial-flow-grid.asciidoc
+++ b/documentation/components/tutorial-flow-grid.asciidoc
@@ -244,7 +244,7 @@ Template renderers are covered later in this tutorial.
 ----
 // Sets a simple text header
 nameColumn.setHeader("Name");
-// Sets a header containing a custom template,
+// Sets a header using Html component,
 // in this case simply bolding the caption "Name"
 nameColumn.setHeader(new Html("<b>Name</b>"));
 

--- a/documentation/components/tutorial-flow-grid.asciidoc
+++ b/documentation/components/tutorial-flow-grid.asciidoc
@@ -10,7 +10,7 @@ layout: page
 
 `Grid` is for displaying and editing tabular data laid out in rows
 and columns. At the top, a __header__ can be shown, and a __footer__ at the
-bottom. In addition to plain text, the header and footer can contain HTML and
+bottom. In addition to plain text, the header and footer can contain
 components. Having components in the header allows implementing filtering
 easily. The grid data can be sorted by clicking on a column header;
 shift-clicking a column header enables secondary sorting criteria.
@@ -246,11 +246,11 @@ Template renderers are covered later in this tutorial.
 nameColumn.setHeader("Name");
 // Sets a header containing a custom template,
 // in this case simply bolding the caption "Name"
-nameColumn.setHeader("<b>Name</b>");
+nameColumn.setHeader(new Html("<b>Name</b>"));
 
 // Similarly for the footer
 nameColumn.setFooter("Name");
-nameColumn.setFooter("<b>Name</b>");
+nameColumn.setFooter(new Html("<b>Name</b>"));
 ----
 
 === Column Order

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/components/GridBasic.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/components/GridBasic.java
@@ -199,7 +199,7 @@ public class GridBasic {
 
         // Sets a simple text header
         nameColumn.setHeader("Name");
-        // Sets a header containing a custom template,
+        // Sets a header using Html component,
         // in this case simply bolding the caption "Name"
         nameColumn.setHeader(new Html("<b>Name</b>"));
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/components/GridBasic.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/components/GridBasic.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.grid.Grid;
@@ -200,11 +201,11 @@ public class GridBasic {
         nameColumn.setHeader("Name");
         // Sets a header containing a custom template,
         // in this case simply bolding the caption "Name"
-        nameColumn.setHeader("<b>Name</b>");
+        nameColumn.setHeader(new Html("<b>Name</b>"));
 
         // Similarly for the footer
         nameColumn.setFooter("Name");
-        nameColumn.setFooter("<b>Name</b>");
+        nameColumn.setFooter(new Html("<b>Name</b>"));
     }
 
     public void gridSorting() {


### PR DESCRIPTION
Headers don't support HTML markup directly like in V8. Use a Html component to put HTML in headers.

https://vaadin.com/forum/thread/17466949/using-html-text-in-grid-header-row

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/422)
<!-- Reviewable:end -->
