### PR TITLE
Avoid linking to a third party web site

### DIFF
--- a/documentation/routing/tutorial-routing-annotation.asciidoc
+++ b/documentation/routing/tutorial-routing-annotation.asciidoc
@@ -38,7 +38,7 @@ public class SomePathComponent extends Div {
 }
 ----
 
-* Assuming your app is running from the root context, when the user navigates to `http://yourdomain.com/some/path`, either by clicking a link in the application or entering the address in the address bar, the `SomePathComponent` component is shown on the page. 
+* Assuming your app is running from the root context, when the user navigates to `\http://example.com/some/path`, either by clicking a link in the application or entering the address in the address bar, the `SomePathComponent` component is shown on the page. 
 
 [NOTE]
 If you omit the `@Route` annotation parameter, the route target is derived from the class name. For example, MyEditor becomes "myeditor", PersonView becomes "person" and MainView becomes "".


### PR DESCRIPTION
 * use reserved example.com domain as example
 * use backslash to avoid displaying that as link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/537)
<!-- Reviewable:end -->
