### PR TITLE
Remove the bower and webjar references from the documentation

### DIFF
--- a/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/IconButton.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/IconButton.java
@@ -4,15 +4,18 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("web-components/creating-java-api-for-a-web-component.asciidoc")
 @Tag("vaadin-button")
-@HtmlImport("bower_components/vaadin-button/vaadin-button.html")
-@HtmlImport("bower_components/vaadin-icons/vaadin-icons.html")
+@NpmPackage("@vaadin/vaadin-button")
+@JsModule("@vaadin/vaadin-button/vaadin-button.js")
+@NpmPackage("@vaadin/vaadin-icons")
+@JsModule("@vaadin/vaadin-icons/vaadin-icons.js")
 public class IconButton extends Component {
 
     private VaadinIcon icon;

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.tutorial.webcomponent;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
@@ -2,14 +2,13 @@ package com.vaadin.flow.tutorial.webcomponent;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("web-components/creating-an-in-project-web-component.asciidoc")
 public class InProject {
     @Tag("my-test-element")
-    @JavaScript("my-test-element/my-test-element.js")
+    @JsModule("my-test-element/my-test-element.js")
     public class MyTest extends Component {
 
         public MyTest(String prop1) {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/InProject.java
@@ -2,14 +2,14 @@ package com.vaadin.flow.tutorial.webcomponent;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("web-components/creating-an-in-project-web-component.asciidoc")
 public class InProject {
     @Tag("my-test-element")
-    @HtmlImport("bower_components/my-test-element/my-test-element.html")
+    @JavaScript("my-test-element/my-test-element.js")
     public class MyTest extends Component {
 
         public MyTest(String prop1) {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/b/PaperSlider.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/webcomponent/b/PaperSlider.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 import com.vaadin.flow.tutorial.webcomponent.ClickEvent;
@@ -13,7 +14,8 @@ import com.vaadin.flow.tutorial.webcomponent.ClickEvent;
 @CodeFor("web-components/creating-java-api-for-a-web-component.asciidoc")
 //@formatter:off
 @Tag("paper-slider")
-@HtmlImport("bower_components/paper-slider/paper-slider.html")
+@NpmPackage("@polymer/paper-slider")
+@JsModule("@polymer/paper-slider/paper-slider.js")
 public class PaperSlider extends AbstractSinglePropertyField<PaperSlider, Integer> {
 
     private static final PropertyDescriptor<Boolean, Boolean> pinProperty = PropertyDescriptors.propertyWithDefault("pin", false);

--- a/documentation/web-components/creating-an-in-project-web-component.asciidoc
+++ b/documentation/web-components/creating-an-in-project-web-component.asciidoc
@@ -6,53 +6,51 @@ layout: page
 
 = Creating an In-project Web Component
 
-To integrate existing, public web components it typically makes sense to do as described above in "Integrating a Polymer Web component". If you want to create a UI component which is specific to the application project you are working on, you can integrate and develop it within your application project instead. Assuming you have an existing project, here the https://vaadin.com/start/lts/project-base project is used as an example, you need to
+To integrate existing, public web components it typically makes sense to do as described above in "Integrating a Polymer Web component".
+If you want to create a UI component which is specific to the application project you are working on, you can integrate and develop it within your application project instead.
+Assuming you have an existing project, here the https://vaadin.com/start/lts/project-base project is used as an example, you need to
 
 1. Install Polymer CLI if you do not have it installed
-2. Use Polymer CLI to create a new Polymer element in the `src/main/webapp/frontend/bower_components` in your project
+2. Use Polymer CLI to create a new Polymer element in the `frontend` directory in your project
 3. Create a Java API for the component
 
-## Install Polymer CLI
-You can find extensive Polymer CLI installation instructions at https://www.polymer-project.org/2.0/docs/tools/polymer-cli
-
+== Install Polymer CLI
 In short you need to install:
 1. Node / npm
 2. Git
-3. Bower
-4. Polymer-cli
-
-If you have node, npm and git installed, you can install bower and polymer-cli as
-[source, sh]
-----
-npm install -g bower polymer-cli
-----
+3. Polymer-cli
+You can find extensive Polymer CLI installation instructions at https://polymer-library.polymer-project.org/3.0/docs/tools/polymer-cli
 
 == Create a New Polymer Element
 
-You can find extensive instructions on how to create a Polymer element at https://www.polymer-project.org/2.0/docs/tools/create-element-polymer-cli
+You can find extensive instructions on how to create a Polymer element at https://polymer-library.polymer-project.org/3.0/docs/tools/create-element-polymer-cli
 
-Assuming you name your Polymer element `my-test-element` (the name MUST contain at least one dash), the element needs to end up in `src/main/webapp/frontend/bower_components/my-test-element`and the main HTML must be `src/main/webapp/frontend/bower_components/my-test-element/my-test-element.html`.
+Assuming you name your Polymer element `my-test-element` (the name MUST contain at least one dash),
+the element needs to end up in `frontend/my-test-element/`and the main HTML must be `frontend/my-test-element/my-test-element.html`.
 
 To get the files in the correct place you can do
 [source, sh]
 ----
-mkdir -p src/main/webapp/frontend/bower_components/my-test-element
-cd src/main/webapp/frontend/bower_components/my-test-element
-polymer init --name polymer-2-element
-rm -rf bower.json  bower_components/ demo polymer.json README.md test index.html
+mkdir -p frontend/my-test-element/
+cd frontend/my-test-element/
+polymer init --name polymer-3-element
+rm -rf package.json package-lock.json node_modules/ demo/ test/ polymer.json README.md index.html .gitignore
 ----
 
-The last command removes a lot of files generated for your Polymer element. This is done for clarity as the files, especially the `bower_components` folder inside your `my-test-element` folder, will not be used by Flow. If you want to add dependencies, you should add these as webjar dependencies in the project.
+The last command removes a lot of files generated for your Polymer element.
+This is done for clarity as the files, especially the `node_modules` folder inside your `my-test-element` folder, will not be used by Flow.
+If you want to add dependencies, you should add these as via `@NpmPackage` in the Java part of the project.
 
 == Create a Java API for the Component
 
-This works exactly as described in <<creating-java-api-for-a-web-component#,Creating Java API for a Web Component>>. The only difference is that static files are loaded from your project instead of from a webjar and you can modify them easily while creating the Java API.
+This works exactly as described in <<creating-java-api-for-a-web-component#,Creating Java API for a Web Component>>.
+The only difference is that static files are loaded from your project instead of from a webjar and you can modify them easily while creating the Java API.
 
 As an example, for the generated `my-test-element`, you could do
 [source, java]
 ----
 @Tag("my-test-element")
-@HtmlImport("bower_components/my-test-element/my-test-element.html")
+@JavaScript("my-test-element/my-test-element.js")
 public class MyTest extends Component {
 
     public MyTest(String prop1) {

--- a/documentation/web-components/creating-an-in-project-web-component.asciidoc
+++ b/documentation/web-components/creating-an-in-project-web-component.asciidoc
@@ -10,38 +10,29 @@ To integrate existing, public web components it typically makes sense to do as d
 If you want to create a UI component which is specific to the application project you are working on, you can integrate and develop it within your application project instead.
 Assuming you have an existing project, here the https://vaadin.com/start/lts/project-base project is used as an example, you need to
 
-1. Install Polymer CLI if you do not have it installed
-2. Use Polymer CLI to create a new Polymer element in the `frontend` directory in your project
-3. Create a Java API for the component
+1. Create a Polymer 3 template for the component
+2. Create a Java API for the component
 
-== Install Polymer CLI
-In short you need to install:
-1. Node / npm
-2. Git
-3. Polymer-cli
-You can find extensive Polymer CLI installation instructions at https://polymer-library.polymer-project.org/3.0/docs/tools/polymer-cli
+== Template
 
-== Create a New Polymer Element
+Create a `frontend/my-test-element/my-test-element.js` file with the following contents:
 
-You can find extensive instructions on how to create a Polymer element at https://polymer-library.polymer-project.org/3.0/docs/tools/create-element-polymer-cli
-
-Assuming you name your Polymer element `my-test-element` (the name MUST contain at least one dash),
-the element needs to end up in `frontend/my-test-element/`and the main HTML must be `frontend/my-test-element/my-test-element.html`.
-
-To get the files in the correct place you can do
-[source, sh]
+[source, js]
 ----
-mkdir -p frontend/my-test-element/
-cd frontend/my-test-element/
-polymer init --name polymer-3-element
-rm -rf package.json package-lock.json node_modules/ demo/ test/ polymer.json README.md index.html .gitignore
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+
+class MyTestElement extends PolymerElement {
+  static get template() {
+    return html`
+      <h2>Hello</h2>
+    `;
+  }
+}
+
+window.customElements.define('my-test-element', MyTestElement);
 ----
 
-The last command removes a lot of files generated for your Polymer element.
-This is done for clarity as the files, especially the `node_modules` folder inside your `my-test-element` folder, will not be used by Flow.
-If you want to add dependencies, you should add these as via `@NpmPackage` in the Java part of the project.
-
-== Create a Java API for the Component
+== Java part
 
 This works exactly as described in <<creating-java-api-for-a-web-component#,Creating Java API for a Web Component>>.
 The only difference is that static files are loaded from your project instead of from a webjar and you can modify them easily while creating the Java API.

--- a/documentation/web-components/creating-an-in-project-web-component.asciidoc
+++ b/documentation/web-components/creating-an-in-project-web-component.asciidoc
@@ -50,7 +50,7 @@ As an example, for the generated `my-test-element`, you could do
 [source, java]
 ----
 @Tag("my-test-element")
-@JavaScript("my-test-element/my-test-element.js")
+@JsModule("my-test-element/my-test-element.js")
 public class MyTest extends Component {
 
     public MyTest(String prop1) {

--- a/documentation/web-components/creating-another-type-of-addon.asciidoc
+++ b/documentation/web-components/creating-another-type-of-addon.asciidoc
@@ -6,9 +6,10 @@ layout: page
 
 = Creating Another type of Add-on
 
-If you want to create an add-on which is not a UI component, e.g. a data provider, you can still use the same component starter described in <<integrating-a-web-component#,Integrating a Web Component>>. Leave the default web component URL in the starter form, download the project and delete:
+If you want to create an add-on which is not a UI component, e.g. a data provider, you can still use the same component starter described in <<integrating-a-web-component#,Integrating a Web Component>>.
+Leave the default web component URL in the starter form, download the project and delete:
 
-1. The webjar dependency
+1. The `@NpmPackage` annotations
 2. The UI component class
 
 You now have a generic project which can be used for any add-on purposes and which supports Directory deployment using

--- a/documentation/web-components/creating-another-type-of-addon.asciidoc
+++ b/documentation/web-components/creating-another-type-of-addon.asciidoc
@@ -9,7 +9,7 @@ layout: page
 If you want to create an add-on which is not a UI component, e.g. a data provider, you can still use the same component starter described in <<integrating-a-web-component#,Integrating a Web Component>>.
 Leave the default web component URL in the starter form, download the project and delete:
 
-1. The `@NpmPackage` annotations
+1. The `@NpmPackage` and `@JsModule` annotations
 2. The UI component class
 
 You now have a generic project which can be used for any add-on purposes and which supports Directory deployment using

--- a/documentation/web-components/creating-java-api-for-a-web-component.asciidoc
+++ b/documentation/web-components/creating-java-api-for-a-web-component.asciidoc
@@ -6,7 +6,8 @@ layout: page
 
 = Creating Java API for a Web Component
 
-The component class, e.g. `PaperSlider.java` you get when using the component starter, see <<integrating-a-web-component#,Integrating a Web Component>> is just a stub which handles the imports. There are multiple ways to interact with a web component but the typical pattern is:
+The component class, e.g. `PaperSlider.java` you get when using the component starter, see <<integrating-a-web-component#,Integrating a Web Component>> is just a stub which handles the imports.
+There are multiple ways to interact with a web component but the typical pattern is:
 
 * Use properties on the element to define how it should behave
 * Listen to events on the element to get notified of when the user does something
@@ -15,7 +16,9 @@ The component class, e.g. `PaperSlider.java` you get when using the component st
 
 == Setting and reading properties
 
-You can typically find out what properties an element supports from its JS docs, e.g. for paper-slider:  https://www.webcomponents.org/element/PolymerElements/paper-slider/elements/paper-slider. The slider has a boolean property called `pin` which defines if "numeric value label is shown when the slider thumb is pressed". To create a `setPin(boolean pin)` Java API for this, you can add:
+You can typically find out what properties an element supports from its JS docs, e.g. for paper-slider: https://www.webcomponents.org/element/PolymerElements/paper-slider/elements/paper-slider.
+The slider has a boolean property called `pin` which defines if "numeric value label is shown when the slider thumb is pressed".
+To create a `setPin(boolean pin)` Java API for this, you can add:
 
 [source, java]
 ----
@@ -39,7 +42,9 @@ public DemoView() {
 ----
 you will see the pin appear when dragging the slider knob.
 
-While you can use the `getElement` methods directly like above, you will end up in defining the property in two places: the getter and the setter. To avoid repeating the property name and to be able to define all properties in one place, there is a `PropertyDescriptor` helper. Using `PropertyDescriptor` and the factory methods in `PropertyDescriptors`, you can define the `pin` property as a static field in the component and use the `PropertyDescriptor` in the getter and the setter:
+While you can use the `getElement` methods directly like above, you will end up in defining the property in two places: the getter and the setter.
+To avoid repeating the property name and to be able to define all properties in one place, there is a `PropertyDescriptor` helper.
+Using `PropertyDescriptor` and the factory methods in `PropertyDescriptors`, you can define the `pin` property as a static field in the component and use the `PropertyDescriptor` in the getter and the setter:
 
 [source, java]
 ----
@@ -57,13 +62,16 @@ public class PaperSlider extends Component {
 }
 ----
 
-The `pinProperty` descriptor here defines a property with the name `pin` and a default value of `false` (matches the web component) and both a setter and getter type of `Boolean` through generics (`<Boolean, Boolean>`). The setter and getter code then only invokes the descriptor with the component instance.
+The `pinProperty` descriptor here defines a property with the name `pin` and a default value of `false` (matches the web component) and both a setter and getter type of `Boolean` through generics (`<Boolean, Boolean>`).
+The setter and getter code then only invokes the descriptor with the component instance.
 
 == Synchronizing the Value
 
-`paper-slider` is an input type component where the user can decide the what the value is. These kind of components should be integrated using the `HasValue` interface so they can automatically work in forms where you use `Binder`.
+`paper-slider` is an input type component where the user can decide the what the value is.
+These kind of components should be integrated using the `HasValue` interface so they can automatically work in forms where you use `Binder`.
 
-The value should be synchronized automatically from the client to the server, when the user changes it, and from the server to the client, when changing it form code. Additionally a value change event should be emitted on the server whenever the value changes.
+The value should be synchronized automatically from the client to the server, when the user changes it, and from the server to the client, when changing it form code.
+Additionally a value change event should be emitted on the server whenever the value changes.
 For the most common case where `getValue()` is based on a single element property, the `AbstractSinglePropertyField` base class can be used to take care of everything related to the value.
 
 [source, java]
@@ -78,7 +86,8 @@ public class PaperSlider extends AbstractSinglePropertyField<PaperSlider, Intege
 ----
 
 The type parameters define the component type (`PaperSlider`) returned by `getSource()` in value change events and the value type (`Integer`).
-The constructor parameters define the name of the element property that contains the value (`value`), the default value to use if there property isn't set (`0`)  and whether `setValue(null)` should be allowed or throw an exception (`false`, meaning that `null` is not allowed).
+The constructor parameters define the name of the element property that contains the value (`value`), the default value to use if there property isn't set (`0`)
+and whether `setValue(null)` should be allowed or throw an exception (`false`, meaning that `null` is not allowed).
 
 [NOTE]
 For more advanced cases that still rely on only one element property, there's an alternative constructor for defining callbacks that convert between the low-level element property type and the high level `getValue()` type.
@@ -108,11 +117,13 @@ public DemoView() {
 ----
 
 [NOTE]
-Some web components also update other properties that are not related to `HasValue`. <<../creating-components/tutorial-component-basic#,Creating A Simple Component Using the Element API>> describes how you can use the `@Synchronize` annotation to synchronize property values without automatically firing a value change event.
+Some web components also update other properties that are not related to `HasValue`.
+<<../creating-components/tutorial-component-basic#,Creating A Simple Component Using the Element API>> describes how you can use the `@Synchronize` annotation to synchronize property values without automatically firing a value change event.
 
 == Listening to Events
 
-All web elements emit a `click` event when the user click on them. To allow the user of your component to listen to the `click` event, you can use a `ComponentEvent` together with the `@DomEvent` and `@EventData` annnotations:
+All web elements emit a `click` event when the user click on them.
+To allow the user of your component to listen to the `click` event, you can use a `ComponentEvent` together with the `@DomEvent` and `@EventData` annotations:
 
 [source, java]
 ----
@@ -143,9 +154,11 @@ public class ClickEvent extends ComponentEvent<PaperSlider> {
 }
 ----
 
-The `ClickEvent` uses `@DomEvent` to define the name of the DOM event to listen for, `click` in this case. Like all other events fired by a `Component`, it extends `ComponentEvent` which provides a typed `getSource()` method.
+The `ClickEvent` uses `@DomEvent` to define the name of the DOM event to listen for, `click` in this case.
+Like all other events fired by a `Component`, it extends `ComponentEvent` which provides a typed `getSource()` method.
 
-The click event defined above uses two additional constructor parameter annotated with `@EventData` to get the click coordinates from the browser. The expression inside the `@EventData` is evaluated when the event is handled in the browser and can access DOM event properties using a `event.` prefix and element properties using the `element.` prefix, e.g. `event.offsetX`.
+The click event defined above uses two additional constructor parameter annotated with `@EventData` to get the click coordinates from the browser.
+The expression inside the `@EventData` is evaluated when the event is handled in the browser and can access DOM event properties using a `event.` prefix and element properties using the `element.` prefix, e.g. `event.offsetX`.
 
 Finally, you can test the event integration in the demo e.g. by adding to `DemoView.java`:
 
@@ -157,17 +170,21 @@ paperSlider.addClickListener(e -> {
 ----
 
 [NOTE]
-The two first parameters to a `ComponentEvent` constructor must be `PaperSlider source, boolean fromClient` which are filled automatically. Any `@EventData` parameters must be added after those and all additional parameters must have an `@EventData` annotation.
+The two first parameters to a `ComponentEvent` constructor must be `PaperSlider source, boolean fromClient` which are filled automatically.
+Any `@EventData` parameters must be added after those and all additional parameters must have an `@EventData` annotation.
 
 [TIP]
 The click event here is used as an example. You should use the `ClickEvent` already provided in Flow instead, which will provide even more information to the server.
 
 [TIP]
-As the event data expression is evaluated as JavaScript, you can control propagation behavior using e.g. `@EventData("event.preventDefault()") String ignored`. Don't do this. It ain't right. But as long as there is no other API to control this, you can do this.
+As the event data expression is evaluated as JavaScript, you can control propagation behavior using e.g. `@EventData("event.preventDefault()") String ignored`.
+Don't do this. It ain't right. But as long as there is no other API to control this, you can do this.
 
 == Calling Element Functions
 
-In addition to properties and events, many elements offer methods which can be invoked for various reasons, e.g. `vaadin-board` has a `refresh()` method which is called whenever a change is made that the web component itself is not able to detect automatically. To call a function on an element, you can use the `callFunction` method in `Element`, e.g. to offer an API to the `increment` function on `paper-slider`, you could add to `PaperSlider.java`:
+In addition to properties and events, many elements offer methods which can be invoked for various reasons, e.g. `vaadin-board` has a `refresh()` method
+which is called whenever a change is made that the web component itself is not able to detect automatically.
+To call a function on an element, you can use the `callFunction` method in `Element`, e.g. to offer an API to the `increment` function on `paper-slider`, you could add to `PaperSlider.java`:
 
 [source, java]
 ----
@@ -177,7 +194,9 @@ public void increment() {
 ----
 
 [TIP]
-In addition to the method name, `callFunction` takes an arbitrary number of parameters of certain supported types. Supported types are at the time of writing String, Boolean, Integer, Double, the corresponding primitive types, JsonValue, Element and Component references.  See the method javadoc for more information about supported types.
+In addition to the method name, `callFunction` takes an arbitrary number of parameters of certain supported types.
+Supported types are at the time of writing String, Boolean, Integer, Double, the corresponding primitive types, JsonValue, Element and Component references.
+See the method javadoc for more information about supported types.
 
 You can test this by adding a call to `DemoView.java`:
 
@@ -189,10 +208,13 @@ Button incrementJSButton = new Button("Increment using JS", e -> {
 add(incrementJSButton);
 ----
 
-If you do this and added the value change listener described earlier, you will see that you get a notification with the new value after clicking on the button. The notification also indicates that the user changed the value because `isFromClient` checks that the change originates from the browser (as opposed to from the server) but does not differentiate between the cases when a user event changed the value and when a JavaScript call changed it.
+If you do this and added the value change listener described earlier, you will see that you get a notification with the new value after clicking on the button.
+The notification also indicates that the user changed the value because `isFromClient` checks that the change originates from the browser (as opposed to from the server)
+but does not differentiate between the cases when a user event changed the value and when a JavaScript call changed it.
 
 [NOTE]
-This particular example is quite artificial as you are doing a server visit from a button click only to call a Javascript method on another element. It makes more sense if you call `increment()` from some other business logic.
+This particular example is quite artificial as you are doing a server visit from a button click only to call a Javascript method on another element.
+It makes more sense if you call `increment()` from some other business logic.
 
 == Final Slider Integration Result
 
@@ -201,7 +223,8 @@ After doing the steps described above, you should end up with the following `Pap
 [source, java]
 ----
 @Tag("paper-slider")
-@HtmlImport("bower_components/paper-slider/paper-slider.html")
+@NpmPackage("@polymer/paper-slider")
+@JsModule("@polymer/paper-slider/paper-slider.js")
 public class PaperSlider extends AbstractSinglePropertyField<PaperSlider, Integer> {
 
     private static final PropertyDescriptor<Boolean, Boolean> pinProperty = PropertyDescriptors.propertyWithDefault("pin", false);
@@ -232,7 +255,10 @@ This can now be further extended to support more configuration properties like `
 
 == Add Sub Elements to Define Child Contents
 
-Some web components can contain child elements. If the component is a layout type where you just want to add child components, it is enough to implement `HasComponents`. The `HasComponents` interface provides default implementations for `add(Component...)`, `remove(Component…)` and `removeAll()`. As an example, you could implement your own `<div>` wrapper as
+Some web components can contain child elements.
+If the component is a layout type where you just want to add child components, it is enough to implement `HasComponents`.
+The `HasComponents` interface provides default implementations for `add(Component...)`, `remove(Component…)` and `removeAll()`.
+As an example, you could implement your own `<div>` wrapper as
 
 [source, java]
 ----
@@ -253,12 +279,14 @@ add(root);
 
 If you do not want to provide a public `add`/`remove` API, you have two options: use the Element API or create a new `Component` for encapsulating the internal element behavior.
 
-As an example, say you wanted to create a specialized Vaadin Button which can only show a `VaadinIcon`. Using the available `VaadinIcon` enum, which lists the icons in the set, you can do e.g
+As an example, say you wanted to create a specialized Vaadin Button which can only show a `VaadinIcon`.
+Using the available `VaadinIcon` enum, which lists the icons in the set, you can do e.g
 
 [source, java]
 ----
 @Tag("vaadin-button")
-@HtmlImport("bower_components/vaadin-button/vaadin-button.html")
+@NpmPackage("@vaadin/vaadin-button")
+@JsModule("@vaadin/vaadin-button/vaadin-button.js")
 public class IconButton extends Component {
 
     private VaadinIcon icon;
@@ -274,7 +302,7 @@ public class IconButton extends Component {
         getElement().removeAllChildren();
         getElement().appendChild(iconComponent.getElement());
     }
-    
+
     public void addClickListener(
             ComponentEventListener<ClickEvent<IconButton>> listener) {
         addListener(ClickEvent.class, (ComponentEventListener) listener);
@@ -286,9 +314,11 @@ public class IconButton extends Component {
 }
 ----
 
-The relevant part here is in the `setIcon` method. As there happens to be a feature in `VaadinIcon` which creates a component for a given icon (the `create()` call), it is used to create the child element. What remains is then to attach the root element of the child component, done using `getElement().appendChild(iconComponent.getElement());`.
+The relevant part here is in the `setIcon` method. As there happens to be a feature in `VaadinIcon` which creates a component for a given icon (the `create()` call),
+it is used to create the child element. What remains is then to attach the root element of the child component, done using `getElement().appendChild(iconComponent.getElement());`.
 
-In case the `VaadinIcon.create()` method was not available, you would have to resort to either creating the component yourself or using the element API directly. If you use the element API, the `setIcon` method might look something like:
+In case the `VaadinIcon.create()` method was not available, you would have to resort to either creating the component yourself or using the element API directly.
+If you use the element API, the `setIcon` method might look something like:
 
 [source, java]
 ----
@@ -302,12 +332,17 @@ public void setIcon(VaadinIcon icon) {
 }
 ----
 
-The first part is the same but in the second part, the element with the correct tag name `<iron-icon>` is created manually and the `icon` attribute is set to the correct value, defined in `vaadin-icons.html`, e.g. `icon="vaadin:check"` for `VaadinIcon.CHECK`. The element is then attached to the `<vaadin-button>` element, after removing any previous content. With this approach you must also ensure that the `vaadin-button.html` dependency is loaded, otherwise handled by the `Icon` component class:
+The first part is the same but in the second part, the element with the correct tag name `<iron-icon>` is created manually
+and the `icon` attribute is set to the correct value, defined in `vaadin-icons.html`, e.g. `icon="vaadin:check"` for `VaadinIcon.CHECK`.
+The element is then attached to the `<vaadin-button>` element, after removing any previous content.
+With this approach you must also ensure that the `vaadin-button.html` dependency is loaded, otherwise handled by the `Icon` component class:
 
 [source, java]
 ----
-@HtmlImport("bower_components/vaadin-button/vaadin-button.html")
-@HtmlImport("bower_components/vaadin-icons/vaadin-icons.html")
+@NpmPackage("@vaadin/vaadin-button")
+@JsModule("@vaadin/vaadin-button/vaadin-button.js")
+@NpmPackage("@vaadin/vaadin-icons")
+@JsModule("@vaadin/vaadin-icons/vaadin-icons.js")
 public class IconButton extends Component {
 ----
 

--- a/documentation/web-components/debugging-a-web-component-integration.asciidoc
+++ b/documentation/web-components/debugging-a-web-component-integration.asciidoc
@@ -5,25 +5,33 @@ layout: page
 ---
 = Debugging a Web Component Integration
 
-Not everything is smooth sailing and sometimes the component just refuses to work like you want it to. If the problem is on the Java side, you can use your standard IDE debugger to figure out what happens but when the problem is in the browser, it gets a bit trickier. Chrome Inspector is an invaluable tool when trying to figure out what goes wrong. 
+Not everything is smooth sailing and sometimes the component just refuses to work like you want it to.
+If the problem is on the Java side, you can use your standard IDE debugger to figure out what happens but when the problem is in the browser, it gets a bit trickier.
+Chrome Inspector is an invaluable tool when trying to figure out what goes wrong.
 
 == Is the element not configured as it should?
 
-Check with the DOM inspector that the element contains the expected attributes (most of the time properties are synchronized to attributes and vice versa). If the property is not synchronized to an attribute, select the element in the inspector and write `$0.somePropertyName` in the console to check that the value is the expected one.
+Check with the DOM inspector that the element contains the expected attributes (most of the time properties are synchronized to attributes and vice versa).
+If the property is not synchronized to an attribute, select the element in the inspector and write `$0.somePropertyName` in the console to check that the value is the expected one.
 
-== Is an event not sent to the server as you would expect? 
+== Is an event not sent to the server as you would expect?
 
-Select the element, and write `monitorEvents($0,'event-name');` in the console. You will now see a log row if the event is triggered and will know you have the correct event name and that the web component actually fires the event. You can leave out `'event-name'` to log all events but be prepared to see a lot of `mousemove` events. You can also use this to see which properties are defined for the event so that you can know what to include in `@EventData`
+Select the element, and write `monitorEvents($0,'event-name');` in the console.
+You will now see a log row if the event is triggered and will know you have the correct event name and that the web component actually fires the event.
+You can leave out `'event-name'` to log all events but be prepared to see a lot of `mousemove` events. You can also use this to see which properties are defined for the event so that you can know what to include in `@EventData`
 
 == Do you need to debug the Javascript?
 
-If you need to debug what the web component does, use the browser debugger to set breakpoints at suitable places. In more problematic cases, e.g. if the problem occurs on initial setup, you can add a `debugger;` statement to the web component code to make the browser always and automatically break at that point. To do that, you need to get a editable copy of the web component included in your project. One way is to unzip the files from the webjar you are using into the location used by Flow. As the add-on project is a `jar` project it has no `src/main/webapp` folder where you can place static files, instead Jetty is configured to use `src/test/webjar-debug/META-INF/resources` as the webapp folder. This particular folder is chosen so you can unzip a webjar directly into `src/test/webjar-debug` and those files will be used instead of the files in a web jar. 
+If you need to debug what the web component does, use the browser debugger to set breakpoints at suitable places.
+In more problematic cases, e.g. if the problem occurs on initial setup, you can add a `debugger;` statement to the web component code to make the browser always and automatically break at that point.
+To do that, you need to edit the web component included in your project. All the web components used in the project are located in the project root `node_modules` directory.
 
 To debug the `increment()` function in `paper-slider` you can thus do:
 
-1. Unzip `paper-slider-2.0.6.jar` into `src/test/webjar-debug`, e.g. `unzip ~/.m2/repository/org/webjars/bowergithub/polymerelements/paper-slider/2.0.6/paper-slider-2.0.6.jar -d src/test/webjars-debug/`
-2. Add a `debugger` statement to the `increment: function() {` function
-3. Restart Jetty, click on the "Increment" button when the inspector window is open
+1. Launch the project in a dev mode so that any frontend file change is automatically used after the page reload
+2. Find a `paper-slider` in the `node_modules` directory: `node_modules/@polymer/paper-slider`
+3. Add a `debugger` statement to the `increment: function() {` function
+4. Reload the page, if not reloaded automatically, click on the "Increment" button when the inspector window is open
 
 [TIP]
 Disable the cache in the browser network tab to avoid getting old versions of the files you are debugging.

--- a/documentation/web-components/debugging-a-web-component-integration.asciidoc
+++ b/documentation/web-components/debugging-a-web-component-integration.asciidoc
@@ -24,14 +24,15 @@ You can leave out `'event-name'` to log all events but be prepared to see a lot 
 
 If you need to debug what the web component does, use the browser debugger to set breakpoints at suitable places.
 In more problematic cases, e.g. if the problem occurs on initial setup, you can add a `debugger;` statement to the web component code to make the browser always and automatically break at that point.
-To do that, you need to edit the web component included in your project. All the web components used in the project are located in the project root `node_modules` directory.
+To do that, you need to edit the web component included in your project.
+All the components used in this project will be downloaded by `npm` and located in the `node_modules` folder under the project root folder.
 
 To debug the `increment()` function in `paper-slider` you can thus do:
 
-1. Launch the project in a dev mode so that any frontend file change is automatically used after the page reload
+1. Launch the project in dev mode so that any frontend file change is automatically used after the page reload
 2. Find a `paper-slider` in the `node_modules` directory: `node_modules/@polymer/paper-slider`
 3. Add a `debugger` statement to the `increment: function() {` function
-4. Reload the page, if not reloaded automatically, click on the "Increment" button when the inspector window is open
+4. Reload the page, click on the "Increment" button when the inspector window is open
 
 [TIP]
 Disable the cache in the browser network tab to avoid getting old versions of the files you are debugging.

--- a/documentation/web-components/introduction-to-webcomponents.asciidoc
+++ b/documentation/web-components/introduction-to-webcomponents.asciidoc
@@ -6,9 +6,11 @@ layout: page
 
 = What are Web Components?
 
-* Web Components are a collection of web standards allowing you to create new HTML tags with custom name, reusability and full encapsulation on styles & markup.  The standards are promised to be ubiquitous in modern browsers.
+* Web Components are a collection of web standards allowing you to create new HTML tags with custom name, reusability and full encapsulation on styles & markup.
+The standards are promised to be ubiquitous in modern browsers.
 
-* The term "Web Components" might seem unfamiliar at first but in fact, you are already using web components**(*)** when you develop. HTML elements like input, select, or textarea are all browser native web components. In short, native elements have followed the concept of the web components for a long time now.
+* The term "Web Components" might seem unfamiliar at first but in fact, you are already using web components**(*)** when you develop.
+HTML elements like input, select, or textarea are all browser native web components. In short, native elements have followed the concept of the web components for a long time now.
 
 _**(*)** Not to be confused with the uppercase initials - Web Components_
 
@@ -27,7 +29,7 @@ _**HTML Imports is not standardized. It was a specification at the phase of the 
 
 
 == Vaadin and Web components
-Vaadin both makes and maintains a set of Web Components as well as uses them to provide Java web devevelopers API 
+Vaadin both makes and maintains a set of Web Components as well as uses them to provide Java web developers API
 through https://vaadin.com/flow[Vaadin Flow].
 
 To find out more how Vaadin utilizes Web Component:
@@ -44,4 +46,4 @@ To find out more how Vaadin utilizes Web Component:
 
 [3] https://developer.mozilla.org/en-US/docs/Web/Web_Components/HTML_Imports
 
-[4] https://webkit.org/status/#feature-html-imports 
+[4] https://webkit.org/status/#feature-html-imports


### PR DESCRIPTION
Closes #498 

The build fails because the Java code is not adjusted for the documentation changes.
This will be done as part of https://github.com/vaadin/flow-and-components-documentation/pull/542

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/544)
<!-- Reviewable:end -->
