### PR TITLE
Update default Push transport

### DIFF
--- a/documentation/advanced/tutorial-push-configuration.asciidoc
+++ b/documentation/advanced/tutorial-push-configuration.asciidoc
@@ -40,7 +40,7 @@ automatically after `access()` finishes. With the manual mode, you can do the pu
 explicitly with `push()`, which allows more flexibility.
 
 Server push can use several transports: WebSockets, long polling, or combined WebSockets+XHR.
-WebSockets is the default transport.
+WebSockets+XHR is the default transport.
 
 [[push.configuration.annotation]]
 == The `@Push` annotation


### PR DESCRIPTION
Default transport is WEBSOCKET_XHR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/609)
<!-- Reviewable:end -->
