### PR TITLE
fix typo in 'syncIdCheck' description of V12 docs

### DIFF
--- a/documentation/advanced/tutorial-all-vaadin-properties.asciidoc
+++ b/documentation/advanced/tutorial-all-vaadin-properties.asciidoc
@@ -59,7 +59,7 @@ Please consult <<tutorial-push-configuration#, Server Push Configuration>> docum
 |syncIdCheck |
 Returns whether sync id checking is enabled. The sync id is used to gracefully handle situations
 when the client sends a message to a connector that has recently been removed on the server.
-By the fault, it is true.
+By default, it is true.
 
 |sendUrlsAsParameters |
 Returns whether the sending of URL's as GET and POST parameters in requests with content-type


### PR DESCRIPTION
This PR fixes a small typo in the "syncIdCheck" description for v12 docs (related to #647).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/662)
<!-- Reviewable:end -->
