### PR TITLE
Fix tutorial heading

### DIFF
--- a/documentation/embedding-flow-applications/tutorial-webcomponent-properties.asciidoc
+++ b/documentation/embedding-flow-applications/tutorial-webcomponent-properties.asciidoc
@@ -5,6 +5,7 @@ layout: page
 ---
 
 = Properties of Embedded Web Components
+
 In this chapter we will take a look at how we can define web component
 properties for our embedded Vaadin application and how we can handle changes
 to those properties on the server-side. We will also take a look at firing


### PR DESCRIPTION
Fix the heading and first paragraph by adding a line break in between.

If there is no break, both the GH preview and the vaadin-docs build break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/665)
<!-- Reviewable:end -->
