### PR TITLE
Fix typo in `debounce` JavaDoc reference

### DIFF
--- a/documentation/creating-components/tutorial-component-events.asciidoc
+++ b/documentation/creating-components/tutorial-component-events.asciidoc
@@ -227,7 +227,7 @@ public class ContinuousInputEvent
 }
 ----
 
-* See https://vaadin.com/api/platform/com/vaadin/flow/dom/DomListenerRegistration.html[`DomListenerRegistration.debouncer`] in the Javadoc for more about debouncing events.
+* See https://vaadin.com/api/platform/com/vaadin/flow/dom/DomListenerRegistration.html[`DomListenerRegistration.debounce`] in the Javadoc for more about debouncing events.
 
 
 [NOTE]


### PR DESCRIPTION
The method name is `debounce`, not `debouncer`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/703)
<!-- Reviewable:end -->
