### PR TITLE
Removed erroneous suggestion for setting compatibility mode

### DIFF
--- a/documentation/v14-migration/v14-migration-guide.asciidoc
+++ b/documentation/v14-migration/v14-migration-guide.asciidoc
@@ -121,21 +121,11 @@ Alternatively, enable compatibility mode by setting the deployment configuration
 
 If using Spring Boot, setting the `vaadin.compatibilityMode` parameter is the mandatory solution
 as the `web-fragment.xml` added by the `flow-server-compatibility-mode` dependency is not read.
-Instead, add the following line to `application.properties`
+To set the property, you may add the following line to `application.properties`:
 
 [source, text]
 ----
 vaadin.compatibilityMode=true
-----
-
-or, if using Maven, set the property in `pom.xml`:
-
-[source, xml]
-----
-<properties>
-    ...
-    <vaadin.compatibilityMode>true</vaadin.compatibilityMode>
-</properties>
 ----
 
 == Migration steps


### PR DESCRIPTION
Setting `vaadin.compatibilityMode` as a Maven property does nothing for the deployment, so I removed it as this was clearly a non-working suggestion that I added. An alternative that could be suggested is using the `spring-boot-maven-plugin` to set `<jvmArguments>-Dvaadin.compatibilityMode</jvmArguments>` (as is done for production mode in skeleton-starter-flow-spring), but I think it is really enough to recommend one way of activating compatibility mode (using `application.properties`). The migration guide is already getting cluttered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/707)
<!-- Reviewable:end -->
