### PR TITLE
CCDM: add client-side bootstrapping documentation

### DIFF
--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -25,6 +25,10 @@ The Vaadin Flow documentation is arranged in the following sections and we recom
 * <<introduction/introduction-overview#,Introduction to Vaadin Flow>>
 * https://vaadin.com/tutorials/getting-started-with-flow[Getting started with Vaadin Flow]
 
+
+== Client Centric Development Model
+* <<ccdm/client-side-bootstrapping#, Client-side Bootstrapping Mode>>
+
 == Router and Navigation
 * <<routing/tutorial-routing-annotation#,Defining Routes with @Route>>
 * <<routing/tutorial-routing-lifecycle#,Navigation Lifecycle>>

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -5,29 +5,32 @@ layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
+
+WARNING: CCDM is a temporary internal name that might change in the definitive release. This documentation covers the concepts and API as it's being implemented in alpha or pre-beta period, and it might change without any advise.
+
 = Client-side Bootstrapping
 
-Client-side bootstrapping mode is not enabled by default. To turn it on, you need to provide the property `vaadin.clientSideMode=true` as a system property or maven plugin property while building/running an application, e.g. running in dev-mode with client-side bootstrapping enabled: `mvn jetty:run -Dvaadin.clientSideMode`.
+Client-side bootstrapping mode is not enabled by default. To turn it on, you need to provide the property `vaadin.clientSideMode=true` as a system property or maven plugin property while building/running an application, e.g. running in dev-mode with client-side bootstrapping enabled: `mvn jetty:run -Dvaadin.clientSideMode`. It can be also be provided as a servlet container deployment property with the name `clientSideMode`.
 
 === Bootstrap page template
 
-In this `clientSideMode`, instead of generating HTML content in on the server-side, the server uses `frontend/index.html` file as a template to generate the bootstrap page. It processes the template and injects the following additional information:
+In this `clientSideMode`, instead of generating the full HTML content of the host application page, the server uses `frontend/index.html` file as a template to generate the bootstrap page. It processes the template and injects the following additional information:
 
   - `<base href='./relative/to/root'>`: Flow calculates the relative path from the current request path to the root path of the application. So that all the relative links in the template should work correctly.
 
-  - Bundled scripts: Flow adds the bundled scripts which are generated from `frontend/index.js` (or `frontend/index.ts`) and other imported modules. Therefore, in the template `frontend/index.html`, there is no need to include the `index.js` (or `index.ts`) script manually. That will be done automatically by the server when serving the bootstrap page.
+  - Bundled script: Flow adds the bundled script which is generated from `frontend/index.js` (or `frontend/index.ts` if you prefer develop in TypeScript) by webpack (the module bundler used in Flow). Therefore, in the template `frontend/index.html`, there is no need to include the `index.js` (or `index.ts`) script manually. That will be done automatically by the server when serving the bootstrap page.
 
-By using this approach, you can optimize your application to load a minimal page which can quickly show to users. This might reduce the first-loading time compared to the old bootstrapping method which loads a full Vaadin application on the first request. As a result, the first request will load promptly and it will boost the first interaction experience.
+By using this approach, you can optimize your application to load the minimal content to be displayed to users at the first load. This might reduce the first-loading time compared to the old bootstrapping method which loads a full Vaadin application on the first request. As a result, the first request will load promptly ant it will boost the first interaction experience.
 
-NOTE: The frontend directory can be customized by providing the property `vaadin.frontend.frontend.folder` when running the Maven `prepare-frontend` task or `build-frontend`(from `vaadin-maven-plugin`).
+NOTE: The frontend directory can be customized by providing the property `vaadin.frontend.frontend.folder` when running the Maven goals `prepare-frontend`  or `build-frontend` from `vaadin-maven-plugin`.
 
-WARNING: The `index.html` template is always required in frontend directory when `clienSideMode` is active. An exception would be thrown when `index.html` is missing.
+WARNING: The `index.html` template is always required in frontend directory when `clienSideMode` is active. An exception would be thrown when the presence of `index.html` is missing from the frontend directory.
 
 === Modifying the bootstrap page on run-time
 
-Before sending the bootstrap page response to the browser, the content could be modified via a `ClientIndexBootstrapListener`. An implementation of the listener should be added via `ServiceInitEvent` when a VaadinService is initialized. Take a look on the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> on how to configure it.
+Before sending the bootstrap page response to the browser, the content can be modified via a `ClientIndexBootstrapListener`. An implementation of the listener should be added via `ServiceInitEvent` when a VaadinService is initialized. Take a look on the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> on how to configure it.
 
-Here is an example implmenetation of `ClientIndexBootstrapListener` to add additional meta tags into the head of the bootstrap page:
+Here is an example implementation of `ClientIndexBootstrapListener` to add additional meta tags into the head of the bootstrap page:
 
 [source,java]
 ----

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -1,0 +1,60 @@
+---
+title: Client-side bootstrapping in CCDM
+order: 1
+layout: page
+---
+
+ifdef::env-github[:outfilesuffix: .asciidoc]
+= Client-side Bootstrapping
+
+Client-side bootstrapping mode is not enabled by default. To turn it on, you need to provide the property `vaadin.clientSideMode=true` as a system property or maven plugin property while building/running an application, e.g. running in dev-mode with client-side bootstrapping enabled: `mvn jetty:run -Dvaadin.clientSideMode`.
+
+=== Bootstrap page template
+
+In this `clientSideMode`, instead of generating HTML content in on the server-side, the server uses `frontend/index.html` file as a template to generate the bootstrap page. It processes the template and injects the following additional information:
+
+  - `<base href='./relative/to/root'>`: Flow calculates the relative path from the current request path to the root path of the application. So that all the relative links in the template should work correctly.
+
+  - Bundled scripts: Flow adds the bundled scripts which are generated from `frontend/index.js` (or `frontend/index.ts`) and other imported modules. Therefore, in the template `frontend/index.html`, there is no need to include the `index.js` (or `index.ts`) script manually. That will be done automatically by the server when serving the bootstrap page.
+
+By using this approach, you can optimize your application to load a minimal page which can quickly show to users. This might reduce the first-loading time compared to the old bootstrapping method which loads a full Vaadin application on the first request. As a result, the first request will load promptly and it will boost the first interaction experience.
+
+NOTE: The frontend directory can be customized by providing the property `vaadin.frontend.frontend.folder` when running the Maven `prepare-frontend` task or `build-frontend`(from `vaadin-maven-plugin`).
+
+WARNING: The `index.html` template is always required in frontend directory when `clienSideMode` is active. An exception would be thrown when `index.html` is missing.
+
+=== Modifying the bootstrap page on run-time
+
+Before sending the bootstrap page response to the browser, the content could be modified via a `ClientIndexBootstrapListener`. An implementation of the listener should be added via `ServiceInitEvent` when a VaadinService is initialized. Take a look on the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> on how to configure it.
+
+Here is an example implmenetation of `ClientIndexBootstrapListener` to add additional meta tags into the head of the bootstrap page:
+
+[source,java]
+----
+public static class CustomBootstrapPageListener implements
+            ClientIndexBootstrapListener {
+
+    @Override
+    public void modifyBootstrapPage(
+            ClientIndexBootstrapPage clientIndexBootstrapPage) {
+        Document document = clientIndexBootstrapPage.getDocument();
+
+        Element head = document.head();
+
+        head.appendChild(createMeta(document, "og:title", "The Rock"));
+        head.appendChild(createMeta(document, "og:type", "video.movie"));
+        head.appendChild(createMeta(document, "og:url",
+                "http://www.imdb.com/title/tt0117500/"));
+        head.appendChild(createMeta(document, "og:image",
+                "http://ia.media-imdb.com/images/rock.jpg"));
+    }
+
+    private Element createMeta(Document document, String property,
+            String content) {
+        Element meta = document.createElement("meta");
+        meta.attr("property", property);
+        meta.attr("content", content);
+        return meta;
+    }
+}
+----

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -24,7 +24,7 @@ By using this approach, you can optimize your application to load the minimal co
 
 NOTE: The frontend directory can be customized by providing the property `vaadin.frontend.frontend.folder` when running the Maven goals `prepare-frontend`  or `build-frontend` from `vaadin-maven-plugin`.
 
-WARNING: The `index.html` template is always required in frontend directory when `clienSideMode` is active. An exception would be thrown when the presence of `index.html` is missing from the frontend directory.
+WARNING: The presence of `index.html` template is always required in the frontend directory when `clienSideMode` is active. An exception would be thrown when `index.html` is missing.
 
 === Modifying the bootstrap page on run-time
 

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -31,7 +31,7 @@ Here is an example implmenetation of `ClientIndexBootstrapListener` to add addit
 
 [source,java]
 ----
-public static class CustomBootstrapPageListener implements
+public class CustomBootstrapPageListener implements
             ClientIndexBootstrapListener {
 
     @Override

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -59,6 +59,21 @@
             <artifactId>vaadin-cdi</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>1.2</version>

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.tutorial.ccdm;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.vaadin.flow.server.ClientIndexBootstrapListener;
+import com.vaadin.flow.server.ClientIndexBootstrapPage;
+import com.vaadin.flow.tutorial.annotations.CodeFor;
+
+@CodeFor("ccdm/client-side-bootstrapping.asciidoc")
+public class ClientSideBootstrapPage {
+    public class CustomBootstrapPageListener implements
+            ClientIndexBootstrapListener {
+
+        @Override
+        public void modifyBootstrapPage(
+                ClientIndexBootstrapPage clientIndexBootstrapPage) {
+            Document document = clientIndexBootstrapPage.getDocument();
+
+            Element head = document.head();
+
+            head.appendChild(createMeta(document, "og:title", "The Rock"));
+            head.appendChild(createMeta(document, "og:type", "video.movie"));
+            head.appendChild(createMeta(document, "og:url",
+                    "http://www.imdb.com/title/tt0117500/"));
+            head.appendChild(createMeta(document, "og:image",
+                    "http://ia.media-imdb.com/images/rock.jpg"));
+        }
+
+        private Element createMeta(Document document, String property,
+                String content) {
+            Element meta = document.createElement("meta");
+            meta.attr("property", property);
+            meta.attr("content", content);
+            return meta;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <flow.version>2.0-SNAPSHOT</flow.version>
+        <flow.version>3.0-SNAPSHOT</flow.version>
         <vaadin.version>14.0-SNAPSHOT</vaadin.version>
     </properties>
 </project>


### PR DESCRIPTION
This PR adds the very first piece of documentation about client-side bootstrapping: taking `index.html` file as a template for bootstrapping from clientside. 
Since it is not really clear how we should organize the documentation right now, we temporarily put it in the same place as Flow's documentation. They will probably move after https://github.com/vaadin/flow/issues/6141 is resolved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/729)
<!-- Reviewable:end -->
