### PR TITLE
bower needs to be installed too

### DIFF
--- a/documentation/v14-migration/v14-migration-guide.asciidoc
+++ b/documentation/v14-migration/v14-migration-guide.asciidoc
@@ -144,9 +144,9 @@ annotations with `@JsModule` annotations, see <<migration-tool#,Migration Tool>>
 
 ==== Install npm
 
-Install npm and Node.js on your development platform of choice if you don't
+Install npm, bower and Node.js on your development platform of choice if you don't
 already have them. Either download the installer
-(https://nodejs.org/en/download/[https://nodejs.org/en/download/]) or use your
+(https://nodejs.org/en/download/[https://nodejs.org/en/download/]), (https://bower.io/[https://bower.io/]) or use your
 preferred package management system (Homebrew, dpkg, ...).
 
 ==== Miscellaneous


### PR DESCRIPTION
Running mvn vaadin:migrate-to-p3, returns an error Could not locate bower. Install it manually on your system and re-run migration goal.

Installing bower on the development machine, fixes it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/756)
<!-- Reviewable:end -->
