### PR TITLE
Update vaadin-themable-mixin docs links

### DIFF
--- a/documentation/theme/integrating-component-theme.asciidoc
+++ b/documentation/theme/integrating-component-theme.asciidoc
@@ -105,4 +105,4 @@ You need to provide theme files for all components used in your application. Omi
 
 == Creating a Custom Component Theme
 
-Theming for the Vaadin components is built using `Vaadin.ThemableMixin`. See the link:https://github.com/vaadin/vaadin-themable-mixin/wiki[vaadin-themable-mixin documentation] to learn more.
+Theming for the Vaadin components is built using `Vaadin.ThemableMixin`. See the link:https://github.com/vaadin/vaadin-themable-mixin#readme[vaadin-themable-mixin documentation] to learn more.

--- a/documentation/theme/using-component-themes.asciidoc
+++ b/documentation/theme/using-component-themes.asciidoc
@@ -137,7 +137,7 @@ Both themes are a part of the `vaadin-core` dependency. To use the ready-made Va
 
 Both themes provide customization points for Vaadin components. These allow you to fine tune component appearance and UX. You can customize using CSS custom properties. See the the *Customization* section of the https://vaadin.com/themes/lumo[Lumo] and https://vaadin.com/themes/material[Material] documentation for more.
 
-Theming for Vaadin components is built using `Vaadin.ThemableMixin`. See the https://github.com/vaadin/vaadin-themable-mixin/wiki[vaadin-themable-mixin] documentation for more. 
+Theming for Vaadin components is built using `Vaadin.ThemableMixin`. See the https://github.com/vaadin/vaadin-themable-mixin#readme[vaadin-themable-mixin] documentation for more. 
 
 === Defining Global Theme Variants
 


### PR DESCRIPTION
vaadin-themable-mixin documentation has been moved from the GitHub Wiki
to the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/794)
<!-- Reviewable:end -->
