### PR TITLE
Split titles into separate words

### DIFF
--- a/documentation/components/tutorial-flow-grid.asciidoc
+++ b/documentation/components/tutorial-flow-grid.asciidoc
@@ -468,7 +468,7 @@ Conceptually, there are three types of renderer:
 
 There are several basic renderers that you can use to configure grid columns.
 
-==== LocalDateRenderer
+==== Local Date Renderer
 
 Use `LocalDateRenderer` to render `LocalDate` objects in the cells.
 
@@ -495,7 +495,7 @@ grid.addColumn(new LocalDateRenderer<>(
     .setHeader("Estimated delivery date");
 ----
 
-==== LocalDateTimeRenderer
+==== Local Date Time Renderer
 
 Use `LocalDateTimeRenderer` to render `LocalDateTime` objects in the cells.
 
@@ -523,7 +523,7 @@ grid.addColumn(new LocalDateTimeRenderer<>(
 ).setHeader("Purchase date and time");
 ----
 
-==== NumberRenderer
+==== Number Renderer
 
 Use `NumberRenderer` to render any type of Number in the cells. It is especially useful for rendering floating-point values.
 
@@ -548,7 +548,7 @@ grid.addColumn(new NumberRenderer<>(
 ).setHeader("Price");
 ----
 
-==== NativeButtonRenderer
+==== Native Button Renderer
 
 Use `NativeButtonRenderer` to create a clickable button in the cells. It creates a native `<button>` on the client side. Click and tap (for touch devices) events are handled on the server side.
 


### PR DESCRIPTION
The titles are using ALLCAPS on the website, which makes it hard to read these titles.

Arguably, we should change the website styling. So, feel free to discard this change if you feel the titles should reflect the exact Java class names. My personal opinion is that titles/headings should be without code formatting, just human-readable text.

### Before

<img width="796" alt="Screenshot 2019-09-16 at 12 19 25" src="https://user-images.githubusercontent.com/66382/64946875-7dd27680-d87c-11e9-969f-d3f6e180ada4.png">

### After

<img width="779" alt="Screenshot 2019-09-16 at 12 19 43" src="https://user-images.githubusercontent.com/66382/64946893-83c85780-d87c-11e9-96f1-1ebc65feeec4.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/806)
<!-- Reviewable:end -->
