### PR TITLE
add example of vaadin-maven-plugin

### DIFF
--- a/documentation/v14-migration/v14-addon-guide.asciidoc
+++ b/documentation/v14-migration/v14-addon-guide.asciidoc
@@ -57,6 +57,24 @@ For creating the Vaadin 14 version of your component add-on, you should first:
 modules or profiles of your add-on
 * If you test your add-on in production mode, you need to switch the goal for
 the production build profile to `build-frontend` (previously two goals)
+* If the `vaadin-maven-plugin` configuration is missing from your project,
+you can add it to the `<plugins>` section of your `pom.xml` as follows:
+
+[source, xml]
+----
+    <plugin>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
+        <version>${vaadin.version}</version>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>prepare-frontend</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+----
 
 == Migrating an Add-on with External Frontend Dependencies
 


### PR DESCRIPTION
Add-on projects made for V10 might not have a `vaadin-maven-plugin` configuration, added an example of that

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/813)
<!-- Reviewable:end -->
