### PR TITLE
Improve documentation under "Importing JavaScript and HTML files"

### DIFF
--- a/documentation/importing-dependencies/tutorial-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-importing.asciidoc
@@ -4,45 +4,49 @@ order: 2
 layout: page
 ---
 
-= Importing HTML and JavaScript
+= Importing JavaScript, JavaScript modules, and HTML
 
-You can add HTML imports and JavaScript to your host page directly from your Java classes.
+You can add JavaScript, JavaScript modules, and HTML imports (compatibility mode) to your host page directly from your Java classes.
 
 [NOTE]
 Polymer 3 templates should be imported using `@JsModule` (see <<../polymer-templates/tutorial-template-basic#,Creating Polymer Templates>> for more information). Only use `@HtmlImport` for importing Polymer 2 templates if your application is running in compatibility mode, and `@JavaScript` for importing plain `.js` files.
 
- 
-There are two ways to add HTML and JavaScript files. Both have the same effect and you can use whichever suits you best.
+There are two ways to add JavaScript and HTML files. Both have the same effect and you can use whichever suits you best.
 
-. Using the `@JavaScript` and `@HtmlImport` annotations.
+. Using the `@JavaScript`, `@JsModule`, and `@HtmlImport` annotations.
 +
-*Example*: Importing HTML and JavaScript files into `HtmlComponent`.
+*Example*: Importing HTML and JavaScript files into `CustomComponent`.
 +
 [source,java]
 ----
 @Tag("div")
+@JsModule("./src/my-module.js")
 @JavaScript("/js/script.js")
 @HtmlImport("/html/htmlimport.html")
-static class HtmlComponent extends Component
+static class CustomComponent extends Component
         implements HasText {
   // implementation omitted
 }
 ----
 
-* Both annotations are repeatable. Add one annotation for each file you need to add. 
+* All the annotations are repeatable. Add one annotation for each file you need to add.
 
-. Using the `addHtmlImport(String url)` and `addJavaScript(String url)` methods from the `Page` class.
+. Using the `addJavaScript(String url)` and `addHtmlImport(String url)` methods from the `Page` class.
+The `Page` class also has method `addJsModule(String url)` but it is meant to be used to add an external JavaScript module.
 +
-*Example*: Using the `addHtmlImport(String url)` and `addJavaScript(String url)` methods to import HTML and JavaScript files.
+*Example*: Using the `addJavaScript(String url)` and `addHtmlImport(String url)` methods to import HTML and JavaScript files.
 +
 [source,java]
 ----
   private void addDependencies() {
     UI.getCurrent().getPage()
-            .addHtmlImport("/html/htmlimport.html");
-    UI.getCurrent().getPage()
             .addJavaScript("/js/script.js");
+    UI.getCurrent().getPage()
+            .addHtmlImport("/html/htmlimport.html");
+    // external JavaScript module
+    UI.getCurrent().getPage()
+            .addJsModule("https://unpkg.com/lodash@4.17.15")
   }
 ----
 
-See <<tutorial-ways-of-importing#,Storing and Loading Resources>> for more on storing your resources and configuring advanced resource loading. 
+See <<tutorial-ways-of-importing#,Storing and Loading Resources>> for more on storing your resources, configuring advanced resource loading, and resource load ordering.

--- a/documentation/importing-dependencies/tutorial-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-importing.asciidoc
@@ -45,7 +45,7 @@ The `Page` class also has method `addJsModule(String url)` but it is meant to be
             .addHtmlImport("/html/htmlimport.html");
     // external JavaScript module
     UI.getCurrent().getPage()
-            .addJsModule("https://unpkg.com/lodash@4.17.15")
+            .addJsModule("https://unpkg.com/lodash@4.17.15");
   }
 ----
 

--- a/documentation/importing-dependencies/tutorial-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-importing.asciidoc
@@ -6,7 +6,7 @@ layout: page
 
 = Importing JavaScript, JavaScript modules, and HTML
 
-You can add JavaScript, JavaScript modules, and HTML imports (compatibility mode) to your host page directly from your Java classes.
+You can add classic JavaScript source files, JavaScript modules, and HTML imports (compatibility mode) to your host page directly from your Java classes.
 
 [NOTE]
 Polymer 3 templates should be imported using `@JsModule` (see <<../polymer-templates/tutorial-template-basic#,Creating Polymer Templates>> for more information). Only use `@HtmlImport` for importing Polymer 2 templates if your application is running in compatibility mode, and `@JavaScript` for importing plain `.js` files.
@@ -29,7 +29,7 @@ static class CustomComponent extends Component
 }
 ----
 
-* All the annotations are repeatable. Add one annotation for each file you need to add.
+* All the resource annotations are repeatable. Add one annotation for each file you need to add.
 
 . Using the `addJavaScript(String url)` and `addHtmlImport(String url)` methods from the `Page` class.
 The `Page` class also has method `addJsModule(String url)` but it is meant to be used to add an external JavaScript module.

--- a/documentation/importing-dependencies/tutorial-include-css.asciidoc
+++ b/documentation/importing-dependencies/tutorial-include-css.asciidoc
@@ -103,8 +103,8 @@ document.head.appendChild(documentContainer.content);
 . Use the `@JsModule("./shared-styles.js")` annotation in a component class, like your main layout class.
 
 === Using CssImport
-The new `@CssImport` annotation can be used to load cs files into the global scope.
-Create a normal css file under `{project directory}/frontend/styles` and use the annotation to bundle the css into frontend resources.
+The new `@CssImport` annotation can be used to load CSS files into the global scope.
+Create a normal CSS file under `{project directory}/frontend/styles` and use the annotation to bundle the CSS into frontend resources.
 
 [source,html]
 ----

--- a/documentation/importing-dependencies/tutorial-include-css.asciidoc
+++ b/documentation/importing-dependencies/tutorial-include-css.asciidoc
@@ -25,9 +25,9 @@ public class MainLayout extends Component {
 }
 ----
 
-* The snippet uses the `@StyleSheet` annotation on a component. 
-* The value of the annotation is a URL from which the style sheet loads. 
-* The style sheet is loaded when the component displays for the first time in the browser. 
+* The snippet uses the `@StyleSheet` annotation on a component.
+* The value of the annotation is a URL from which the style sheet loads.
+* The style sheet is loaded when the component displays for the first time in the browser.
 * You can use the annotation multiple times on the same component.
 
 . Using the `addStyleSheet(String url)` method from the `Page` class. 
@@ -54,6 +54,8 @@ Be cautious when including global styles for your application. If the user's bro
 See <<../web-components/integrating-a-web-component#,Integrating a Web Component>> for more, and *Browser support* at https://www.webcomponents.org/[webcomponents.org] for a list of browsers that support Web Components and those that require polyfills. 
 
 Web Component normally uses their own styles that are specifically scoped for each component. If the browser does not support Web Components, the missing functionality is polyfilled, and the Web Component is no longer treated as a scoped unit, but rather as a regular part of the DOM tree. Global styles are applied to it in the same way as any other HTML element.
+
+=== Using JavaScript template
 
 To prevent global styles leaking into the local DOM of Web Components, you can use the `<custom-style>` extension:
 
@@ -99,5 +101,27 @@ document.head.appendChild(documentContainer.content);
 ----
 
 . Use the `@JsModule("./shared-styles.js")` annotation in a component class, like your main layout class.
+
+=== Using CssImport
+The new `@CssImport` annotation can be used to load cs files into the global scope.
+Create a normal css file under `{project directory}/frontend/styles` and use the annotation to bundle the css into frontend resources.
+
+[source,html]
+----
+// custom-styles.css
+html {
+  color: red;
+}
+----
+
+[source,java]
+----
+// MainLayout.java
+@CssImport("./styles/custom-styles.css")
+@Route("")
+public class MainLayout extends VerticalLayout{
+
+}
+----
 
 See <<../theme/theming-crash-course#,Theming Web Components>> and https://polymer-library.polymer-project.org/3.0/api/elements/custom-style[Polymer.CustomStyle] for more.

--- a/documentation/importing-dependencies/tutorial-include-css.asciidoc
+++ b/documentation/importing-dependencies/tutorial-include-css.asciidoc
@@ -108,7 +108,6 @@ Create a normal css file under `{project directory}/frontend/styles` and use the
 
 [source,html]
 ----
-// custom-styles.css
 html {
   color: red;
 }
@@ -116,10 +115,9 @@ html {
 
 [source,java]
 ----
-// MainLayout.java
 @CssImport("./styles/custom-styles.css")
 @Route("")
-public class MainLayout extends VerticalLayout{
+public class MainLayout extends Component {
 
 }
 ----

--- a/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
@@ -10,10 +10,10 @@ layout: page
 === Static frontend resources for Webpack bundling (14 npm mode)
 In Vaadin 14, static resources that are bundled using Webpack and referenced via `@JavaScript`, `@JsModule`, and `CssImport` annotations should be placed under `{project directory}/frontend`.
 This includes normal JavaScript files, Polymer 3 template files, and CSS files.
-When importing these files using the annotations, prefix the path with `./` which signifies the `frontend/` directory.
+When importing files using these annotations, prefix the path with `./`, which signifies the `frontend/` directory.
 For example, a CSS file `my-custom.css` under `{project directory}/frontend/styles/my-custom.css` would be referenced `@CssImport("./styles/my-custom.css")`.
 
-If the `./` prefix is missing from a `@JsModule` annotation, the import is assumed to be a reference to npm module under `node_modules/` folder.
+If the `./` prefix is missing from a `@JsModule` annotation, the import is treated as a reference to an npm module under `node_modules/` folder.
 
 === Static resources
 This section covers static resource locations when in either compatibility mode or using resources that should not be bundled by Webpack.
@@ -56,7 +56,7 @@ Imported dependency files of the same type, load in the order they are defined i
 For example, CSS files load in the `@CssImport` annotation definition order, JavaScript files in the `JsModule` and  `@JavaScript` annotation definition order.
 
 The loading order of imported dependencies is only guaranteed for one file type, in one class.
-Specifically, loading order is not guaranteed between classes; Annotations on class `A` could be imported before or after annotations on class `B`.
+Specifically, loading order is not guaranteed between classes; annotations on class `A` could be imported before or after annotations on class `B`.
 
 Frontend resources bundled by Webpack also have a type group ordering;
 JavaScript files loaded by `@JsModule` annotation come always before JavaScript files loaded by `@JavaScript`, and both of those come before CSS files loaded by `@CssImport`.

--- a/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
@@ -7,6 +7,17 @@ layout: page
 
 == Storing Resources
 
+=== Static frontend resources for Webpack bundling (14 npm mode)
+In Vaadin 14, static resources that are bundled using Webpack and referenced via `@JavaScript`, `@JsModule`, and `CssImport` annotations should be placed under `{project directory}/frontend`.
+This includes normal JavaScript files, Polymer 3 template files, and CSS files.
+When importing these files using the annotations, prefix the path with `./` which signifies the `frontend/` directory.
+For example, a CSS file `my-custom.css` under `{project directory}/frontend/styles/my-custom.css` would be referenced `@CssImport("./styles/my-custom.css")`.
+
+If the `./` prefix is missing from a `@JsModule` annotation, the import is assumed to be a reference to npm module under `node_modules/` folder.
+
+=== Static resources
+This section covers static resource locations when in either compatibility mode or using resources that should not be bundled by Webpack.
+
 You can place your resource files (CSS style sheets, JavaScript and HTML files, and other static resources) in any folder in your WAR file, except `/VAADIN`, which is reserved for internal framework use.
 
 `VaadinServlet` handles static resource requests, if you have mapped it to `/*`.
@@ -28,45 +39,63 @@ When you configure an element, for example setting the `src` attribute for an `<
 
 == Advanced configuration of CSS, JavaScript and HTML imports
 
-As discussed in <<tutorial-include-css#,Including Style Sheets>> and <<tutorial-importing#,Importing HTML and JavaScript>>, you can import client side dependencies or resource files using:
+As discussed in <<tutorial-include-css#,Including Style Sheets>> and <<tutorial-importing#,Importing HTML and JavaScript>>, you can import client-side dependencies or resource files using:
 
-* Annotations (`@StyleSheet`, `@JavaScript` and `@HtmlImport`), and 
-* Methods provided by the `Page` class (`addStyleSheet`, `addHtmlImport)` and `addJavaScript)`.
+* Annotations (`@JavaScript`, `@JsModule`, `@CssImport`, `@StyleSheet`, and `@HtmlImport`), and
+* Methods provided by the `Page` class (`addJavaScript`, `addJsModule`, `addStyleSheet`, and `addHtmlImport`).
 
-Sometimes the way client-side resources are loaded to the browser affects the functionality of the application. Vaadin Flow provides advanced methods to configure the loading of these resources.
+[NOTE]
+`@HtmlImport` and `addHtmlImport` work only in compatibility mode and while `@StyleSheet` does work as before, `@CssImport` may be a better fit.
+
+Sometimes the way client-side resources are loaded to the browser affects the functionality of the application.
+Vaadin Flow provides advanced methods to configure the loading of these resources.
 
 === Dependency Loading Order
 
-Imported dependency files of the same type, load in the order they are defined in the class. For example, CSS files load in the `@StyleSheet` annotation definition order, JavaScript files in the `@JavaScript` annotation definition order, and HTML files in the `@HtmlImport` annotation definition order.  
+Imported dependency files of the same type, load in the order they are defined in the class.
+For example, CSS files load in the `@CssImport` annotation definition order, JavaScript files in the `JsModule` and  `@JavaScript` annotation definition order.
 
-The loading order of imported dependencies is only guaranteed for one file type, in one class. There are no other loading-order guarantees. Specifically, loading order is not guaranteed between classes or files types. 
+The loading order of imported dependencies is only guaranteed for one file type, in one class.
+Specifically, loading order is not guaranteed between classes; Annotations on class `A` could be imported before or after annotations on class `B`.
+
+Frontend resources bundled by Webpack also have a type group ordering;
+JavaScript files loaded by `@JsModule` annotation come always before JavaScript files loaded by `@JavaScript`, and both of those come before CSS files loaded by `@CssImport`.
+The exception to this rule are `@JsModule` annotations of files annotated with `@Theme`.
+All JavaScript modules found on such classes are imported before other file types. This covers both `Lumo` and `Material` themes as well as custom themes created by the developer.
+
 
 *Example*: Imported dependencies of different file types in a single class. 
 
 [source, java]
 ----
 @JavaScript("1.js")
-@StyleSheet("1.css")
-@HtmlImport("1.html")
+@JsModule("a.js")
+@CssImport("1.css")
 @JavaScript("2.js")
-@StyleSheet("2.css")
-@HtmlImport("2.html")
+@JsModule("b.js")
+@CssImport("2.css")
 static class OrderedDependencies extends Div {
 }
 ----
-* `1.js` will be imported before `2.js`, `1.css` before `2.css`, `1.html` before `2.html`, but there are no other guarantees.
+* The loading order of the files will be: `a.js`, `b.js`, `1.js`, `2.js`, `1.css`, and `2.css`.
+Imports on other classes could be before or after the imports present here (within each file group).
 
-You can control the load order of dependencies of different file types, by adding imports within an HTML import. 
+You can control the load order of dependencies of different file types, by adding imports within an JavaScript import.
 
+*Example*: Ensuring `custom-css.js` runs before `javascript-file.js`.
+The `custom-css.js` uses the technique for wrapping CSS into JavaScript presented in <<tutorial-include-css#,Including Style Sheets>>.
 
-*Example*: Ensuring `htmlimport4.html` runs before `htmlimport4-js.js`.
-[source, html]
+[source, javascript]
 ----
-<link rel="import" href="htmlimport4.html">
-<script src="htmlimport4-js.js"></script>
+import '../styles/custom-css.js';
+import './javascript-file.js';
 ----
 
 === Using the loadMode Parameter
+
+[NOTE]
+`LoadMode` does not affect files that are bundled by Webpack.
+Those files will be included into the frontend resource bundle and will thus be available after the bundle has been loaded.
 
 All annotations and methods in the `Page` class without explicit `LoadMode` parameter use `LoadMode.EAGER`, by default.
 
@@ -134,3 +163,114 @@ public class MainLayout extends Component {
 
 
 * Dependencies with the same load mode are guaranteed to load in the order defined in the component. This is true for all load modes.
+
+== Resource Cheat Sheet
+
+=== Vaadin 14 with npm
+.Non-Spring projects
+|===
+|File type |Import |File location
+
+|CSS files
+|`@CssImport("./my-styles/styles.css")`<<foot-1,[1]>>
+|`/frontend/my-styles/styles.css`
+
+|JavaScript and Polymer templates
+|`@JsModule("./src/my-script.js")`<<foot-1,[1]>>
+|`/frontend/src/my-script.js`
+
+|Static files, e.g. images
+|`new Image("img/flower.jpg", "A flower")`
+|`/src/main/webapp/img/flower.jpg`
+|===
+
+.Spring projects
+|===
+|File type |Import |File location
+
+|CSS files
+|`@CssImport("./my-styles/styles.css")`<<foot-1,[1]>>
+|`/frontend/my-styles/styles.css`
+
+|JavaScript and Polymer templates
+|`@JsModule("./src/my-script.js")`<<foot-1,[1]>>
+|`/frontend/src/my-script.js`
+
+|Static files, e.g. images
+|`new Image("img/flower.jpg", "A flower")`
+|`/src/main/resources/META-INF/resources/img/flower.jpg`
+|===
+
+.Add-ons
+|===
+|File type |Import |File location
+
+|CSS files
+|`@CssImport("./my-styles/styles.css")`<<foot-1,[1]>>
+|`/src/main/resources/META-INF/resources/frontend/my-styles/styles.css`
+
+|JavaScript and Polymer templates
+|`@JsModule("./src/my-script.js")`<<foot-1,[1]>>
+|`/src/main/resources/META-INF/resources/frontend/src/my-script.js`
+
+|Static files, e.g. images
+|`new Image("img/flower.jpg", "A flower")`
+|`/src/main/resources/META-INF/resources/img/flower.jpg`
+|===
+
+=== Vaadin 10-13, Vaadin 14 in compatibility mode
+
+.Non-Spring projects
+|===
+|File type |Import |File location
+
+|CSS files
+|`@StyleSheet("css/styles.css")`<<foot-2,[2]>>
+|`/src/main/webapp/frontend/css/styles.css`
+
+|Polymer templates, custom-style and dom-module styles
+|`@HtmlImport("src/template.html")`
+|`/src/main/webapp/frontend/src/template.html`
+
+|JavaScript
+|`@JavaScript("js/script.js")`<<foot-3,[3]>>
+|`/src/main/webapp/frontend/js/script.js`
+
+|Static files, e.g. images
+|`new Image("img/flower.jpg", "A flower")`
+|`/src/main/webapp/img/flower.jpg`
+|===
+
+.Spring projects and add-ons
+|===
+|File type |Import |File location
+
+|CSS files
+|`@StyleSheet("css/styles.css")`<<foot-2,[2]>>
+|`/src/main/resources/META-INF/resources/frontend/css/styles.css`
+
+|Polymer templates, custom-style and dom-module styles
+|`@HtmlImport("src/template.html")`
+|`/src/main/resources/META-INF/resources/frontend/src/template.html`
+
+|JavaScript
+|`@JavaScript("js/script.js")`<<foot-3,[3]>>
+|`/src/main/resources/META-INF/resources/frontend/js/script.js`
+
+|Static files, e.g. images
+|`new Image("img/flower.jpg", "A flower")`
+|`/src/main/resources/META-INF/resources/img/flower.jpg`
+|===
+
+=== Footnotes
+
+[[foot-1]]
+. The `@JsModule` and `@CssImport` annotations can also be used for importing from an npm package.
+In this case, the path is defined as `@JsModule("@polymer/paper-input")` or `@CssImport("some-package/style.css")`.
+Paths referring to the local frontend directory should be prefixed with `./`.
+[[foot-2]]
+. The `@StyleSheet` annotation can also be used in Vaadin 14 with npm.
+The same paths as in V10-V13 can be used, including the `context://` protocol `@StyleSheet("context://style.css")`, which resolves the path relative to the context path of the web application, like other static files.
+Styles included this way may cause issues with web components.
+[[foot-3]]
+. The `@JavaScript` annotation can also be used in Vaadin 14 with npm. The V14 `/frontend` folder should then be used.

--- a/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
+++ b/documentation/importing-dependencies/tutorial-ways-of-importing.asciidoc
@@ -53,7 +53,7 @@ Vaadin Flow provides advanced methods to configure the loading of these resource
 === Dependency Loading Order
 
 Imported dependency files of the same type, load in the order they are defined in the class.
-For example, CSS files load in the `@CssImport` annotation definition order, JavaScript files in the `JsModule` and  `@JavaScript` annotation definition order.
+For example, CSS files load in the `@CssImport` annotation definition order, JavaScript files in the `@JsModule` and  `@JavaScript` annotation definition order.
 
 The loading order of imported dependencies is only guaranteed for one file type, in one class.
 Specifically, loading order is not guaranteed between classes; annotations on class `A` could be imported before or after annotations on class `B`.

--- a/documentation/src/main/css/IncludingCss.css
+++ b/documentation/src/main/css/IncludingCss.css
@@ -1,0 +1,5 @@
+tutorial::importing-dependencies/tutorial-including-css.asciidoc
+
+html {
+  color: red;
+}

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/importing/Importing.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/importing/Importing.java
@@ -21,8 +21,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
-import com.vaadin.flow.component.dependency.StyleSheet;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("importing-dependencies/tutorial-importing.asciidoc")
@@ -30,9 +29,10 @@ public class Importing {
 
     //@formatter:off - custom line wrapping
     @Tag("div")
+    @JsModule("./src/my-module.js")
     @JavaScript("/js/script.js")
     @HtmlImport("/html/htmlimport.html")
-    static class HtmlComponent extends Component
+    static class CustomComponent extends Component
             implements HasText {
         // implementation omitted
     }
@@ -43,6 +43,9 @@ public class Importing {
                 .addHtmlImport("/html/htmlimport.html");
         UI.getCurrent().getPage()
                 .addJavaScript("/js/script.js");
+        // external JavaScript module
+        UI.getCurrent().getPage()
+                .addJsModule("https://unpkg.com/lodash@4.17.15");
     }
 
 }

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/importing/IncludeCss.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/importing/IncludeCss.java
@@ -17,7 +17,10 @@ package com.vaadin.flow.tutorial.importing;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("importing-dependencies/tutorial-include-css.asciidoc")
@@ -26,8 +29,10 @@ public class IncludeCss {
     //@formatter:off - custom line wrapping
     // Relative to Servlet URL
     @StyleSheet("styles.css")
+    @CssImport("./styles/custom-styles.css")
     // Loaded from external location
     @StyleSheet("http://www.example.com/example.css")
+    @Route("")
     public class MainLayout extends Component {
         // implementation omitted
 
@@ -39,5 +44,4 @@ public class IncludeCss {
         }
     }
     //@formatter:on
-
 }

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/importing/LazyImporting.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/importing/LazyImporting.java
@@ -18,9 +18,7 @@ package com.vaadin.flow.tutorial.importing;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.dependency.JavaScript;
-import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.dependency.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
@@ -50,13 +48,13 @@ public class LazyImporting {
         }
     }
     //@formatter:on
-    
+
     @JavaScript("1.js")
-    @StyleSheet("1.css")
-    @HtmlImport("1.html")
+    @JsModule("a.js")
+    @CssImport("1.css")
     @JavaScript("2.js")
-    @StyleSheet("2.css")
-    @HtmlImport("2.html")
+    @JsModule("b.js")
+    @CssImport("2.css")
     static class OrderedDependencies extends Div {
     }
 

--- a/documentation/src/main/js/WaysOfImporting.js
+++ b/documentation/src/main/js/WaysOfImporting.js
@@ -1,0 +1,4 @@
+// tutorial::importing-dependencies/tutorial-ways-of-importing.asciidoc
+
+import '../styles/custom-css.js';
+import './javascript-file.js';

--- a/documentation/v14-migration/migration-tool.asciidoc
+++ b/documentation/v14-migration/migration-tool.asciidoc
@@ -7,9 +7,15 @@ layout: page
 = Migration Tool for Polymer Templates
 
 Several steps are required to migrate your project to Vaadin 14 from Vaadin 13, 
-see <<v14-migration-guide#,Vaadin 14 Migration Guide>> tutorial.
+see <<v14-migration-guide#,Vaadin 14 Migration Guide>> tutorial. To help with the migration,
+the Vaadin 14 migration tool can update Polymer 2 HTML templates in an existing Vaadin 13
+project into Polymer 3 JavaScript modules.
 
-To help with the migration, the Vaadin Maven plugin can convert Polymer 2 HTML templates into Polymer 3 JavaScript modules.
+The Vaadin 14 migration tool is available in two forms: as a goal in `vaadin-maven-plugin` (for
+Maven-based projects), and as a standalone jar (for other project setups)
+
+== Migrating a Maven Project
+
 The plugin's `migrate-to-p3` goal automates two steps:
 
 * it uses resources directory (by default it is `src/main/webapp`) to locate
@@ -45,7 +51,7 @@ To facilitate this, use the *keepOriginal* parameter to prevent removal of the
 original template files (by default these are removed). 
 See *keepOriginal* parameter description below.
 
-== Goal parameters
+=== Goal parameters
 
 Here we describe the Maven plugin goal's parameters.
 
@@ -59,7 +65,7 @@ Here we describe the Maven plugin goal's parameters.
     files and their conversation to P3. The result files will be moved to the final destination from it.
     
 * *frontendDirectory* (default: `${project.basedir}/frontend`):
-    The resulting directory which will contain converter resource files.
+    The resulting directory which will contain converted resource files.
     
 * *keepOriginal* (default: `false`):
     Whether to keep original resource files or not. By default the converted 
@@ -76,3 +82,74 @@ Here we describe the Maven plugin goal's parameters.
     ** `ALWAY` means rewrite annotations regardless of resource conversation status
     ** `SKIP`  means skip annotations rewrite
     ** `SKIP_ON_ERROR` means rewrite only if there are no errors during resource conversation
+
+
+== Migrating a Project Using the Standalone Tool
+
+The standalone migration tool can be used to migrate projects that do not use Maven. It performs the
+same tasks as the Maven plugin, but requires more parameters since fewer assumptions can be made
+about the project structure.
+
+The standalone migration tool is distributed as a separate `.jar` file, which can be downloaded from
+Maven central:
+https://repo.maven.apache.org/maven2/com/vaadin/flow-migration/
+
+You should download the jar file named `flow-migration-<VERSION>-standalone.jar`, where `<VERSION>` is
+synchronized with Flow release versions. We recommend to to always download the latest version of the
+migration tool.
+
+You can run the jar on the command line (`java -jar flow-migration-<VERSION>-standalone.jar` followed
+by the list of parameters and values). The tool requires the following mandatory parameters (path
+values are absolute, or resolved relative to current working directory if not starting with `/`) unless
+explicitly specified to be relative to `baseDir`:
+
+* `-b,--baseDir <arg>`:
+Base project directory. Normally it is the root of the files to migrate.
+
+* `-c,--classesDir <arg>`:
+Compiled classes directory. Java classes have to be compiled into this directory to be able to apply migration.
+
+* `-d,--depUrls <arg>`:
+Comma-separated classpath URLs. The URLs should include all dependencies for the project such as jars or
+filesystem paths to binary classes.
+
+* `-src,--sourceDirs <arg>`:
+Comma-separated java source directories. The root package directory (e.g. `com`) should exist in this directory.
+
+In addition, the tool supports the following optional parameters:
+
+* `-ars,--annRewrite <arg>`:
+Java annotation rewrite strategy (see above for details). Legal values are
+`ALWAYS`, `SKIP_ON_ERROR` and `SKIP`.
+
+* `-ko,--keepOriginal`:
+See description of *keepOriginal* above.
+
+* `-md,--migrationDir <arg>`:
+See description of *migrateFolder* above.
+
+* `-res,--resourcesDirs <arg>`:
+See description of *resources* above.
+
+* `-se,--stopOnError`:
+Whether migration should stop execution with error if Modulizer has exited with non-zero
+status.
+
+* `-t,--targetDir <arg>`:
+See description of *frontendDirectory* above.
+
+=== Example
+
+To convert a project in directory `/tmp/myproject`, containing Java sources in `/tmp/myproject/src/main/java` and
+compiled Java classes in `/tmp/myproject/target/classes` with default options:
+```
+java -jar flow-migration-<VERSION>-standalone.jar \
+  -b /tmp/myproject
+  -src /tmp/myproject/src/main/java
+  -c /tmp/myproject/target/classes
+  -d file:///tmp/flow-server-2.0.8.jar
+```
+
+Note that `flow-server` is a minimal dependency required for  `-d` (as the standalone
+migration tool is agnostic of the project setup, it needs to be instructed where to find
+the classes that the project depends on, including the Vaadin classes).


### PR DESCRIPTION
Aims to
- fix #706
- fix #778
- fix #803
- fix https://github.com/vaadin/flow/issues/5945

The cheatsheet part is stolen from [Erik's stackoverflow post](https://stackoverflow.com/questions/57553973/where-should-i-place-my-vaadin-10-static-files/57553974#57553974)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/822)
<!-- Reviewable:end -->
