### PR TITLE
Remove warning about style module loading order

### DIFF
--- a/documentation/theme/tutorial-theming-overlay.asciidoc
+++ b/documentation/theme/tutorial-theming-overlay.asciidoc
@@ -81,6 +81,3 @@ If you want to be more specific and target the overlay of `vaadin-dialog`, do no
 public class MyApplicationWithDialog extends Div {
 }
 ----
-
-[NOTE]
-`ThemableMixin` does not guarantee the order in which the style modules are applied. It is important to declare CSS rules whose specificity is greater than the Lumo properties that are being overridden. 


### PR DESCRIPTION
Lumo and Material style modules are loaded with lower priority than user provided style modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/838)
<!-- Reviewable:end -->
