### PR TITLE
fix: make client-side docs more consistent

### DIFF
--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -26,8 +26,8 @@ The Vaadin Flow documentation is arranged in the following sections and we recom
 * https://vaadin.com/tutorials/getting-started-with-flow[Getting started with Vaadin Flow]
 
 
-== Client Centric Development Model
-* <<ccdm/quick-start-guide#, Client-side Quick Start Guide>>
+== Creating UI in TypeScript
+* <<ccdm/quick-start-guide#, Quick Start Guide>>
 * <<ccdm/client-side-bootstrapping#, Client-side Bootstrapping>>
 * <<ccdm/client-side-routing#, Client-side Routing>>
 * <<ccdm/typescript-support#, TypeScript Support>>

--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -171,7 +171,7 @@ The Vaadin Flow documentation is arranged in the following sections and we recom
 * <<advanced/tutorial-push-access#,Asynchronous Updates>>
 * <<advanced/tutorial-push-broadcaster#,Creating Collaborative Views>>
 * <<advanced/tutorial-dependency-filter#,Modifying how dependencies are loaded with DependencyFilters>>
-* <<advanced/tutorial-service-init-listener#,Configure RequestHandlers, ClientIndexBootstrapListeners and DependencyFilters using VaadinServiceInitListener>>
+* <<advanced/tutorial-service-init-listener#,Configure RequestHandlers, IndexHtmlRequestListeners and DependencyFilters using VaadinServiceInitListener>>
 * <<advanced/tutorial-dynamic-content#,Showing Dynamic Content>>
 * <<advanced/tutorial-history-api#,History API>>
 * <<advanced/tutorial-stream-resources#,Using stream resources>>

--- a/documentation/advanced/tutorial-application-lifecycle.asciidoc
+++ b/documentation/advanced/tutorial-application-lifecycle.asciidoc
@@ -198,12 +198,12 @@ gets the request as a [classname]#VaadinRequest#.
 === Customizing the Loader Page
 
 The HTML content of the loader page is generated as an HTML DOM object, which
-can be customized by implementing a [interfacename]#ClientIndexBootstrapListener# that
+can be customized by implementing a [interfacename]#IndexHtmlRequestListener# that
 modifies the DOM object. To do so, you need to extend the
 [classname]#VaadinServlet# and add a [interfacename]#SessionInitListener# to the
 service object, as outlined in <<application.lifecycle.session>>. You can then
 add the bootstrap listener to a session with
-[methodname]#addClientIndexBootstrapListener()# when the session is initialized.
+[methodname]#addIndexHtmlRequestListener()# when the session is initialized.
 
 Loading the widget set is handled in the loader page with functions defined in a
 separate [filename]#BootstrapHandler.js# script whose content is inlined into the page.

--- a/documentation/advanced/tutorial-service-init-listener.asciidoc
+++ b/documentation/advanced/tutorial-service-init-listener.asciidoc
@@ -9,7 +9,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 = VaadinServiceInitListener
 
 `VaadinServiceInitListener` can be used to configure RequestHandlers,
-<<../ccdm/client-side-bootstrapping#,ClientIndexBootstrapListener>> and <<tutorial-dependency-filter#,DependencyFilters>>.
+<<../ccdm/client-side-bootstrapping#,IndexHtmlRequestListener>> and <<tutorial-dependency-filter#,DependencyFilters>>.
 You can also use it to <<../routing/tutorial-router-dynamic-routes#application.startup,dynamically register routes during the
 application startup>>.
 
@@ -23,8 +23,8 @@ public class ApplicationServiceInitListener
 
     @Override
     public void serviceInit(ServiceInitEvent event) {
-        event.addClientIndexBootstrapListener(response -> {
-            // ClientIndexBootstrapListener to change the bootstrap page
+        event.addIndexHtmlRequestListener(response -> {
+            // IndexHtmlRequestListener to change the bootstrap page
         });
 
         event.addDependencyFilter((dependencies, filterContext) -> {

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Client-side Bootstrapping in CCDM
-order: 1
+order: 20
 layout: page
 ---
 
@@ -26,35 +26,35 @@ flow.start();
 For applications that are built in Java and do not include any client-side views the client-side bootstrapping process is transparent.
 A default `index.html` / `index.js` pair is generated during the build, and immediately loads the server-side `UI` when the app starts.
 If there is a need to add a client-side view to the application later, it can be done incrementally, with minimal modifications.
-See more details on this in the <<#default-bootstrap-template-and-entry-point,Default Bootstrap Template and Entry Point>> section below.
+See more details on this in the <<default-bootstrap-template-and-entry-point,Default Bootstrap Template and Entry Point>> section below.
 
 [NOTE]
-If you are migrating from an earlier version of Vaadin, check the <<#migrating-from-vaadin-10-14,Migrating from Vaadin 10-14>> section below.
+If you are migrating from an earlier version of Vaadin, check the <<migrating-from-vaadin-10-14,Migrating from Vaadin 10-14>> section below.
 
 
-=== Starting a Flow App from Client-side Code
+== Starting a Flow App from Client-side Code
 
 When using client-side bootstrapping, Vaadin does not automatically load the Flow client or create a server-side `UI` instance for the app.
 The Flow JavaScript API offers two ways to start a Flow app from the client-side:
 
  - `flow.serverSideRoutes`: add a fallback route into a client-side routing configuration with Vaadin Router. This is the way to go if the application has a combination of client-side and server-side views. See the <<client-side-routing#,Client-side Routing>> page for more details.
 
- - `flow.start()`: start a Flow app and let it take full control over the current browser page. This is the way to go if the application has only server-side views. See the <<#default-index-ts,default `index.ts` file>> below on this page.
+ - `flow.start()`: start a Flow app and let it take full control over the current browser page. This is the way to go if the application has only server-side views. See the <<default-index-ts,default `index.ts` file>> below on this page.
 
 By using either of these two approaches, you can optimize your application to load the minimal content to be displayed to users at the first load. This might reduce the first-loading time compared to the Vaadin 10-14 bootstrapping method which loads a full Vaadin application on the first request. As a result, the first request loads promptly and that improves the first interaction experience.
 
 
-=== Bootstrap Page Template [[bootstrap-page-template]]
+== Bootstrap Page Template [[bootstrap-page-template]]
 
 When using client-side bootstrapping, Vaadin servlet uses the `frontend/index.html` file as a template to generate the bootstrap page response. It processes the template and injects the following additional information:
 
   - `<base href='./relative/to/root'>`: Vaadin calculates the relative path from the current request path to the root path of the application. That is required for relative links in the app view templates to work correctly.
 
-  - Bundled script: Vaadin automatically adds the bundled and optimized script generated from the `frontend/index.ts` file (or `frontend/index.js` if you prefer to develop in JavaScript). It uses a pre-configured link:https://webpack.js.org/[Webpack] instance that's included together with `vaadin-maven-plugin` as a module bundler. Therefore, in the `frontend/index.html` template there is no need to include the `index.ts` (or `index.js`) script manually.
+  - Bundled script: Vaadin automatically adds the bundled and optimized script generated from the `frontend/index.ts` file (or `frontend/index.js` if you prefer to develop in JavaScript). It uses a pre-configured link:https://webpack.js.org/[Webpack^] instance that's included together with `vaadin-maven-plugin` as a module bundler. Therefore, in the `frontend/index.html` template there is no need to include the `index.ts` (or `index.js`) script manually.
 
 NOTE: The frontend directory can be customized by providing the property `vaadin.frontend.frontend.folder` when running the Maven goals `prepare-frontend`  or `build-frontend` from `vaadin-maven-plugin`.
 
-==== Default Bootstrap Template and Entry Point [[default-bootstrap-template-and-entry-point]]
+=== Default Bootstrap Template and Entry Point [[default-bootstrap-template-and-entry-point]]
 
 If the `index.html` or `index.ts` (and `index.js`) in the frontend folder are missing, `vaadin-maven-plugin` generates a default corresponding file in the `target` folder. The generated files bootstrap and load the application using server-side routing. You can take control of these files by creating them in the `frontend` folder. The default content of the files are as following:
 
@@ -127,7 +127,7 @@ In case you have an `index.ts` in your frontend folder but there is no `tsconfig
 
 ----
 
-=== Modifying the Bootstrap Page on Runtime
+== Modifying the Bootstrap Page on Runtime
 
 Before sending the bootstrap page response to the browser, the content can be modified via a `ClientIndexBootstrapListener`. An implementation of the listener should be added via a `ServiceInitEvent` when a `VaadinService` is initialized. Take a look on the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> on how to configure it.
 
@@ -164,7 +164,7 @@ public class CustomBootstrapPageListener implements
 ----
 
 
-=== Migrating from Vaadin 10-14 [[migrating-from-vaadin-10-14]]
+== Migrating from Vaadin 10-14 [[migrating-from-vaadin-10-14]]
 
 For applications migrated from earlier versions of Vaadin, client-side bootstrapping requires replacing the usages of the V10-14 `BootstrapHandler` APIs with their `ClientIndexHtmlHandler` API counterparts as described in link:https://github.com/vaadin/flow/issues/6584[TBD (see flow#6584)].
 
@@ -174,7 +174,7 @@ The reason for this API change is that with clien-side bootstrapping the initial
 
  - In Vaadin 15+ with client-side bootstrapping the `index.html` page includes only the basic HTML page markup and links to the TypeScript (or JavaScript) UI code. The Flow client and a server-side `UI` instance are loaded and created later if (and when) the user navigates to a route that does not have a client-side implementation.
 
-==== Compatibility Mode
+=== Compatibility Mode
 
 If migration from the V10-14 bootstrapping APIs to the V15 client-side bootstrapping APIs is not feasible, it is possible to add a `-Dvaadin.clientSideMode=false` system property when starting the app to keep using the V10-14 bootstrapping process.
 

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -162,7 +162,7 @@ public class MyIndexHtmlRequestListener implements
 
 == Migrating from Vaadin 10-14 [[migrating-from-vaadin-10-14]]
 
-For applications migrated from earlier versions of Vaadin, client-side bootstrapping requires replacing the usages of the V10-14 `BootstrapHandler` APIs with their `ClientIndexHtmlHandler` API counterparts as described in link:https://github.com/vaadin/flow/issues/6584[TBD (see flow#6584)].
+For applications migrated from earlier versions of Vaadin, client-side bootstrapping requires replacing the usages of the V10-14 `BootstrapHandler` APIs with their `IndexHtmlRequestHandler` API counterparts as described in link:https://github.com/vaadin/flow/issues/6584[TBD (see flow#6584)].
 
 The reason for this API change is that with client-side bootstrapping the initial page HTML generation is separated from loading the Flow client and creating a server-side `UI` instance.
 

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -8,8 +8,10 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = Client-side Bootstrapping
 
-Client-side bootstrapping in Vaadin 15+ allows creating applications that have parts of the UI written in TypeScript (or JavaScript), and do not always require a connected server-side <<../introduction/introduction-overview#,`UI`>> instance to run.
-It is one of the building blocks that enable starting an application from the browser cache when offline, navigating between views when offline, and starting the server-side of the app if and when it is needed.
+Client-side bootstrapping allows creating parts of the application UI in TypeScript (or JavaScript).
+It also allows starting an app without creating a connected server-side <<../introduction/introduction-overview#,`UI`>> instance, which makes such applications stateless.
+
+This is one of the building blocks that enable starting an application and navigating between views when offline, and creating applications that are easy to scale because they do not consume server resources for each user session.
 
 .frontend/index.ts
 [source, javascript]
@@ -23,7 +25,7 @@ const flow = new Flow({
 flow.start();
 ----
 
-For applications that are built in Java and do not include any client-side views the client-side bootstrapping process is transparent.
+For applications where the UI is built in Java and does not include any client-side views the client-side bootstrapping process is transparent.
 A default `index.html` / `index.js` pair is generated during the build, and immediately loads the server-side `UI` when the app starts.
 If there is a need to add a client-side view to the application later, it can be done incrementally, with minimal modifications.
 See more details on this in the <<default-bootstrap-template-and-entry-point,Default Bootstrap Template and Entry Point>> section below.
@@ -56,7 +58,7 @@ NOTE: The frontend directory can be customized by providing the property `vaadin
 
 === Default Bootstrap Template and Entry Point [[default-bootstrap-template-and-entry-point]]
 
-If the `index.html` or `index.ts` (and `index.js`) in the frontend folder are missing, `vaadin-maven-plugin` generates a default corresponding file in the `target` folder. The generated files bootstrap and load the application using server-side routing. You can take control of these files by creating them in the `frontend` folder. The default content of the files are as following:
+If the `index.html` or `index.ts` (and `index.js`) files in the frontend folder are missing, `vaadin-maven-plugin` generates a default corresponding file in the `target` folder. The generated files starts the application so that it uses only server-side routing. You can take control of these files by moving them into the `frontend` folder. By default these files look similar to the following:
 
 .Default `index.html`
 [source,html]
@@ -67,7 +69,8 @@ If the `index.html` or `index.ts` (and `index.js`) in the frontend folder are mi
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Polyfills for the Web Component APIs are required to use Web Components
-    in the browsers that do not support these APIs natively (e.g. IE11) -->
+    in the browsers that do not support these APIs natively (e.g. MS Edge) -->
+
   <script src="./VAADIN/build/webcomponentsjs/webcomponents-loader.js" defer></script>
   <!-- index.ts is included here automatically (either by the dev server or during the build) -->
 </head>
@@ -79,30 +82,24 @@ If the `index.html` or `index.ts` (and `index.js`) in the frontend folder are mi
 .Default `index.ts` [[default-index-ts]]
 [source,javascript]
 ----
-
 import { Flow } from '@vaadin/flow-frontend/Flow';
 
 const flow = new Flow({
   // relative path to `projectDir/target/frontend/flow-generated-imports.js`
-  // @ts-ignore
   imports: () => import('../target/frontend/flow-generated-imports.js')
 });
-// Let the flow-server control the application
+
+// load Flow and let it take full control over the browser page
 flow.start();
 ----
 
-NOTE: Follow <<typescript-support#, this link>> for more information about TypeScript support. To mix client-side and server-side routes, you need to install and configure `vaadin-router` as described in <<quick-start-guide#, Quick Start Guide>>
+NOTE: The auto-generated bootstrap template works best for server-side applicaitons. In order add client-side views into the app, please follow the  <<quick-start-guide#, Quick Start Guide>>.
 
-In case you have an `index.ts` in your frontend folder but there is no `tsconfig.json` in your project root, `vaadin-maven-plugin` also generates one.
+Using TypeScript requires a `tsconfig.json` file for the TypeScript compiler. `vaadin-maven-plugin` generates one in case if there an `index.ts` file in the frontend folder but there is no `tsconfig.json` in the project root. The default config look similar to the following:
 
 .Default `tsconfig.json`
 [source,json]
 ----
-// This TypeScript configuration file is generated by vaadin-maven-plugin.
-// This is needed for TypeScript compiler to compile your TypeScript code in the project.
-// It is recommended to commit this file to the VCS.
-// You might want to change the configurations to fit your preferences
-// For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
   "compilerOptions": {
     "sourceMap": true,
@@ -124,24 +121,23 @@ In case you have an `index.ts` in your frontend folder but there is no `tsconfig
   ],
   "exclude": []
 }
-
 ----
 
-== Modifying the Bootstrap Page on Runtime
+== Modifying the Bootstrap Page at the Runtime
 
-Before sending the bootstrap page response to the browser, the content can be modified via a `ClientIndexBootstrapListener`. An implementation of the listener should be added via a `ServiceInitEvent` when a `VaadinService` is initialized. Take a look on the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> on how to configure it.
+Before sending the bootstrap page response to the browser, the content can be modified via an `IndexHtmlRequestListener`. An implementation of the listener should be added via a `ServiceInitEvent` when a `VaadinService` is initialized. Check the <<../advanced/tutorial-service-init-listener#,ServiceInitListener tutorial>> for the details about using Vaadin `ServiceInitListeners`.
 
-Here is an example implementation of `ClientIndexBootstrapListener` to add additional meta tags into the head of the bootstrap page:
+The example below shows how to use the `IndexHtmlRequestListener` API to add custom HTML meta tags dynamically for each page request:
 
 [source,java]
 ----
-public class CustomBootstrapPageListener implements
-            ClientIndexBootstrapListener {
+public class MyIndexHtmlRequestListener implements
+            IndexHtmlRequestListener {
 
     @Override
-    public void modifyBootstrapPage(
-            ClientIndexBootstrapPage clientIndexBootstrapPage) {
-        Document document = clientIndexBootstrapPage.getDocument();
+    public void modifyIndexHtmlResponse(
+            IndexHtmlResponse indexHtmlResponse) {
+        Document document = indexHtmlResponse.getDocument();
 
         Element head = document.head();
 
@@ -168,11 +164,11 @@ public class CustomBootstrapPageListener implements
 
 For applications migrated from earlier versions of Vaadin, client-side bootstrapping requires replacing the usages of the V10-14 `BootstrapHandler` APIs with their `ClientIndexHtmlHandler` API counterparts as described in link:https://github.com/vaadin/flow/issues/6584[TBD (see flow#6584)].
 
-The reason for this API change is that with clien-side bootstrapping the initial page HTML generation is separated from loading the Flow client and creating a server-side `UI` instance.
+The reason for this API change is that with client-side bootstrapping the initial page HTML generation is separated from loading the Flow client and creating a server-side `UI` instance.
 
- - In Vaadin 10 to 14 these two steps are combined and the `index.html` page includes the code and configuration needed to start the Flow client engine and link the page to the server-side `UI` instance.
+ - In Vaadin 10 to 14 these two steps are combined and the `index.html` page includes the code and configuration needed to start the Flow client engine and link the browser page to the server-side `UI` instance.
 
- - In Vaadin 15+ with client-side bootstrapping the `index.html` page includes only the basic HTML page markup and links to the TypeScript (or JavaScript) UI code. The Flow client and a server-side `UI` instance are loaded and created later if (and when) the user navigates to a route that does not have a client-side implementation.
+ - In Vaadin 15+ with client-side bootstrapping the `index.html` page includes only the basic HTML markup and links to the TypeScript (or JavaScript) UI code. When using <<client-side-routing#,client-side routing>>, the Flow client and a server-side `UI` instance are loaded and created later if (and when) the user navigates to a route that does not have a client-side implementation.
 
 === Compatibility Mode
 

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: Client-side Bootstrapping in CCDM
+title: Client-side Bootstrapping
 order: 20
 layout: page
 ---

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -95,7 +95,8 @@ flow.start();
 
 NOTE: The auto-generated bootstrap template works best for server-side applicaitons. In order add client-side views into the app, please follow the  <<quick-start-guide#, Quick Start Guide>>.
 
-Using TypeScript requires a `tsconfig.json` file for the TypeScript compiler. `vaadin-maven-plugin` generates one in case if there an `index.ts` file in the frontend folder but there is no `tsconfig.json` in the project root. The default config look similar to the following:
+Using TypeScript requires a `tsconfig.json` file for the TypeScript compiler. `vaadin-maven-plugin` generates one in case if there is an `index.ts` file in the frontend folder but there is no `tsconfig.json` in the project root.
+The default config looks similar to the following:
 
 .Default `tsconfig.json`
 [source,json]

--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -9,7 +9,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 = Client-side Bootstrapping
 
 Client-side bootstrapping allows creating parts of the application UI in TypeScript (or JavaScript).
-It also allows starting an app without creating a connected server-side <<../introduction/introduction-overview#,`UI`>> instance, which makes such applications stateless.
+It also allows starting an app without creating a connected server-side <<../introduction/introduction-overview#,`UI`>> instance, which means applications can be stateless.
 
 This is one of the building blocks that enable starting an application and navigating between views when offline, and creating applications that are easy to scale because they do not consume server resources for each user session.
 

--- a/documentation/ccdm/client-side-routing.asciidoc
+++ b/documentation/ccdm/client-side-routing.asciidoc
@@ -8,13 +8,16 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = Client-side Routing
 
-Client-side routing adds the ability to combine regular Flow <<../routing/tutorial-routing-annotation#,views in Java>> (server-side views) and client-side views in JavaScript or TypeScript.
+Client-side routing allows combining client-side views created in TypeScript (or JavaScript) with server-side views created in Java using the <<../routing/tutorial-routing-annotation#,`@Route`>> annotation.
 
-It lets you to use link:https://vaadin.com/router[Vaadin Router^] to define routes in your `index.js` or `index.ts` file, and delegate server-side Flow routes when no client-side routes matches.
+This is one of the building blocks that enable navigating between views when offline because it does not require a server connection for navigation between client-side views.
 
-The following snippet which will be explained later, shows how to combine client and side views:
+Client-side routing is based on using link:https://vaadin.com/router[Vaadin Router^] in a  <<client-side-bootstrapping#,client-side bootstrapped>> app.
+Client-side routes are explicitly listed in the routing config, and server-side routes are added there through the `serverSideRoutes` Flow JS API.
 
-.index.js
+The following snippet--explained further on this page--shows how to combine client and server views so that the server-side is invoked when no client-side routes match.
+
+.index.ts
 [source, javascript]
 ----
 import {Router} from '@vaadin/router';
@@ -40,32 +43,18 @@ The `@vaadin/router` module facilitates navigation when client and server views 
 
 The glue for mixing views is the `@vaadin/flow-frontend/Flow` JavaScript module which allows lazy initialization of Flow and navigation to server views.
 
-== Prerequisites
-
- - Vaadin 15+ is needed to enable <<client-side-bootstrapping#,Client Side Bootstrapping>> and use the Flow client module.
- - Vaadin Router link:https://github.com/vaadin/vaadin-router/releases/[1.4.3+^] is needed to properly handle client and server views.
-
-[NOTE]
-If your Vaadin starter project is already configured for client-side bootstrapping, you can skip _installation_ and _usage_ sections in this article.
-
 == Vaadin Router
 
 Vaadin Router is a small yet powerful client-side router JavaScript library. It uses a widely adopted `express.js` syntax for routers (users/:id) to map URLs to views. It has all the features of a modern router: async route resolution, animated transition, child routes, navigation guards, redirects, and more.
 
 Vaadin router works with Web Components regardless of how they are created, it also offers a JavaScript API for regular HTML elements.
 
-=== Installation
-
-It is available as an `npm` package. Run the following command to add the dependency to your project:
-
-[source,bash]
-----
-$ npm install --save @vaadin/router
-----
+Vaadin Router is distributed as the link:https://www.npmjs.com/package/@vaadin/vaadin-router[`@vaadin/vaadin-router`^] npm package.
+It is included into link:https://www.npmjs.com/package/@vaadin/vaadin-core[`@vaadin/vaadin-core`^], and is automatically included into any Vaadin application.
 
 === Usage
 
-Once vaadin router is available in your dependency tree, add it to the `index.js` (or `index.ts`) file by using the `import` statement, then create a router instance by passing the outlet element in the `index.html` file:
+Add Vaadin Router into the `index.ts` (or `index.js`) file by using the `import` statement, then create a `router` instance by passing the outlet element in the `index.html` file:
 
 .index.html
 [source, html]
@@ -79,7 +68,7 @@ Once vaadin router is available in your dependency tree, add it to the `index.js
 ----
 
 
-.index.js
+.index.ts
 [source, javascript]
 ----
 import {Router} from '@vaadin/router';
@@ -107,7 +96,7 @@ router.setRoutes([
 
 == Layouts
 
-When using client routing, it is possible to compose the page layout without server intervention, so as the application shell can be shown when in offline mode.
+When using client-side routing it is possible to compose the page layout without server intervention, so as the application shell can be shown when in offline mode.
 
 Vaadin Router enables layout containers by using the `children` property during the configuration:
 
@@ -137,9 +126,8 @@ Flow provides a client module which acts as a bridge between client router and s
 
 Even though it is possible to integrate Flow with any JavaScript based routing solution, we recommend using Vaadin Router as introduced in the previous section.
 
-=== Installation
-
-Flow client module is not available in `npm` repositories, however it is automatically added to the `node_modules` folder when your Java project depends on Vaadin 15+
+The Flow client is distributed as a part of the link:https://search.maven.org/artifact/com.vaadin/vaadin/[`com.vaadin:vaadin`^] Maven artifact.
+It is automatically included into any Vaadin application and can be imported into any TypeScript (or JavaScript) file as `import {Flow} from '@vaadin/flow-frontend/Flow';`.
 
 === Usage
 
@@ -214,12 +202,13 @@ Lifecycle callbacks are asynchronous.
 The following snippets show how to cancel navigation in a Web Component
 
 [source, javascript]
-.my-demo.js
+.my-demo.ts
 ----
 class MyView extends HTMLElement {
   onBeforeEnter(location, commands, router) {
     return location.pathname === '/cancel' ? commands.prevent() : {};
   }
+}
 customElements.define('my-view', MyView);
 
 router.setRoutes([

--- a/documentation/ccdm/client-side-routing.asciidoc
+++ b/documentation/ccdm/client-side-routing.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Client-side Routing
-order: 2
+order: 30
 layout: page
 ---
 
@@ -10,7 +10,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 Client-side routing adds the ability to combine regular Flow <<../routing/tutorial-routing-annotation#,views in Java>> (server-side views) and client-side views in JavaScript or TypeScript.
 
-It lets you to use link:https://vaadin.com/router[Vaadin Router] to define routes in your `index.js` or `index.ts` file, and delegate server-side Flow routes when no client-side routes matches.
+It lets you to use link:https://vaadin.com/router[Vaadin Router^] to define routes in your `index.js` or `index.ts` file, and delegate server-side Flow routes when no client-side routes matches.
 
 The following snippet which will be explained later, shows how to combine client and side views:
 
@@ -43,7 +43,7 @@ The glue for mixing views is the `@vaadin/flow-frontend/Flow` JavaScript module 
 == Prerequisites
 
  - Vaadin 15+ is needed to enable <<client-side-bootstrapping#,Client Side Bootstrapping>> and use the Flow client module.
- - Vaadin Router link:https://github.com/vaadin/vaadin-router/releases/[1.4.3+] is needed to properly handle client and server views.
+ - Vaadin Router link:https://github.com/vaadin/vaadin-router/releases/[1.4.3+^] is needed to properly handle client and server views.
 
 [NOTE]
 If your Vaadin starter project is already configured for client-side bootstrapping, you can skip _installation_ and _usage_ sections in this article.
@@ -230,7 +230,7 @@ router.setRoutes([
 ]);
 ----
 
-For more information visit vaadin router link:https://vaadin.github.io/vaadin-router/vaadin-router/#/classes/WebComponentInterface[API documentation]
+For more information visit vaadin router link:https://vaadin.github.io/vaadin-router/vaadin-router/#/classes/WebComponentInterface[API documentation^]
 
 === Flow Router navigation lifecycle (server-side views)
 

--- a/documentation/ccdm/quick-start-guide.asciidoc
+++ b/documentation/ccdm/quick-start-guide.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Quick Start Guide
-order: 0
+order: 10
 layout: page
 ---
 
@@ -8,9 +8,9 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = Quick Start Guide
 
-This guide assumes that you already have a Vaadin 15 project, otherwise you can download a starter from the link:https://vaadin.com/start/latest[Vaadin website].
+This guide assumes that you already have a Vaadin 15 project, otherwise you can download a starter from the link:https://vaadin.com/start/latest[Vaadin website^].
 
-If you downloaded a TypeScript starter project, you can skip configuration and go directly to the <<#step-5,step 5>> to add new views.
+If you downloaded a TypeScript starter project, you can skip configuration and go directly to the <<step-5,step 5>> to add new views.
 
 → *Step 1* - Enable <<client-side-bootstrapping#,Client Side Bootstrapping>>
 
@@ -22,7 +22,7 @@ If you downloaded a TypeScript starter project, you can skip configuration and g
 </properties>
 ----
 
-→ *Step 2* - Install link:https://vaadin.com/router/[Vaadin Router] from npm.
+→ *Step 2* - Install link:https://vaadin.com/router/[Vaadin Router^] from npm.
 
 [source,bash]
 ----
@@ -54,9 +54,9 @@ router.setRoutes([
 ----
 
 [NOTE]
-You can use <<typescript-support#TypeScript>> in your project if you'd rather it.
+You can use <<typescript-support#,TypeScript>> in your project if you'd rather it.
 
-→ *Step 4* - Import Flow module to enable link:https://vaadin.com/docs/v14/flow/routing/tutorial-routing-annotation.html[server-side routing]
+→ *Step 4* - Import Flow module to enable <<../routing/tutorial-routing-annotation#,server-side routing>>
 
 .frontend/index.js
 [source, javascript]

--- a/documentation/ccdm/quick-start-guide.asciidoc
+++ b/documentation/ccdm/quick-start-guide.asciidoc
@@ -8,78 +8,18 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = Quick Start Guide
 
-This guide assumes that you already have a Vaadin 15 project, otherwise you can download a starter from the link:https://vaadin.com/start/latest[Vaadin website^].
+NOTE: The quickest and easiest way to get started with Vaadin and TypeScript is to download a starter project from link:https://start.stg.vaadin.com/[start.stg.vaadin.com^].
 
-If you downloaded a TypeScript starter project, you can skip configuration and go directly to the <<step-5,step 5>> to add new views.
+→ *Step 1* - Create a new project at link:https://start.stg.vaadin.com/[start.stg.vaadin.com^]
 
-→ *Step 1* - Enable <<client-side-bootstrapping#,Client Side Bootstrapping>>
+Make sure to select `TypeScript + Spring Boot` as the technology stack.
 
-.pom.xml
-[source, xml]
-----
-<properties>
-  <vaadin.clientSideMode>true</vaadin.clientSideMode>
-</properties>
-----
-
-→ *Step 2* - Install link:https://vaadin.com/router/[Vaadin Router^] from npm.
-
-[source,bash]
-----
-$ npm install --save @vaadin/router
-----
+If you prefer to create a Maven project manually, check the <<preparing-a-project-manually>> section below.
 
 
-→ *Step 3* - Create `frontend/index.html` and `frontend/index.js` to enable <<client-side-routing#,client-side routing>>.
+→ *Step 2* - Add a client-side view and set a route path for it [[step-2]]
 
-.frontend/index.html
-[source, html]
-----
-<html>
-  <body>
-    <div id="outlet"></div>
-  </body>
-</html>
-----
-
-
-.frontend/index.js
-[source, javascript]
-----
-import {Router} from '@vaadin/router';
-const router = new Router(document.querySelector('#outlet'));
-
-router.setRoutes([
-]);
-----
-
-[NOTE]
-You can use <<typescript-support#,TypeScript>> in your project if you'd rather it.
-
-→ *Step 4* - Import Flow module to enable <<../routing/tutorial-routing-annotation#,server-side routing>>
-
-.frontend/index.js
-[source, javascript]
-----
-import {Router} from '@vaadin/router';
-import {Flow} from '@vaadin/flow-frontend/Flow';
-
-const router = new Router(document.querySelector('#outlet'));
-const {serverSideRoutes} = new Flow({
-  imports: () => import('../target/frontend/generated-flow-imports.js')
-});
-
-router.setRoutes([
-  ...serverSideRoutes
-]);
-----
-
-[NOTE]
-Flow API is not distributed via npm repositories but added automatically when running the Vaadin project.
-
-→ *Step 5* [[step-5]] - Add a client-side view and set a route path for it.
-
-.frontend/index.js
+.frontend/index.ts
 [source, javascript]
 ----
 import {Router} from '@vaadin/router';
@@ -104,29 +44,30 @@ router.setRoutes([
 npm install --save '@vaadin/vaadin-button'
 ----
 
-.frontend/app-help.js
+.frontend/app-help.ts
 [source, javascript]
 ----
-import {LitElement, html} from 'lit-element';
+import {LitElement, html, customElement} from 'lit-element';
 import '@vaadin/vaadin-button/vaadin-button';
 
+@customElement('app-help')
 export class AppHelp extends LitElement {
     render() {
-      return html`<vaadin-button @click='${this.click}'>Read More</vaadin-button>`;
+      return html`
+        <vaadin-button @click=${this.click}>Read More</vaadin-button>
+      `;
     }
 
     click(e) {
       console.log('clicked');
     }
 }
-
-customElements.define('app-help', AppHelp);
 ----
 
 NOTE:
 You might want to install all `@vaadin` components at once by running `npm install --save '@vaadin/vaadin-core'`
 
-→ *Step 6* -  Add a server-side view and set the route path for it
+→ *Step 3* -  Add a server-side view and set the route path for it
 
 .src/main/java/com/example/application/ServerView.java
 [source, java]
@@ -138,3 +79,62 @@ public class ServerView extends Div {
     }
 }
 ----
+
+
+== Preparing a project manually [[preparing-a-project-manually]]
+
+→ *Step 0a* - Install link:https://vaadin.com/router/[Vaadin Router^] from npm.
+
+[source,bash]
+----
+$ npm install --save @vaadin/router
+----
+
+→ *Step 0b* - Create `frontend/index.html` and `frontend/index.js` to enable <<client-side-routing#,client-side routing>>.
+
+.frontend/index.html
+[source, html]
+----
+<html>
+  <body>
+    <div id="outlet"></div>
+  </body>
+</html>
+----
+
+
+.frontend/index.ts
+[source, javascript]
+----
+import {Router} from '@vaadin/router';
+const router = new Router(document.querySelector('#outlet'));
+
+router.setRoutes([
+]);
+----
+
+[NOTE]
+You can use <<typescript-support#,TypeScript>> in your project if you'd rather it.
+
+→ *Step 0c* - Import Flow module to enable <<../routing/tutorial-routing-annotation#,server-side routing>>
+
+.frontend/index.ts
+[source, javascript]
+----
+import {Router} from '@vaadin/router';
+import {Flow} from '@vaadin/flow-frontend/Flow';
+
+const router = new Router(document.querySelector('#outlet'));
+const {serverSideRoutes} = new Flow({
+  imports: () => import('../target/frontend/generated-flow-imports.js')
+});
+
+router.setRoutes([
+  ...serverSideRoutes
+]);
+----
+
+Proceed to <<step-2,Step 2>> to add a client-side view.
+
+[NOTE]
+Flow API is not distributed via npm repositories but added automatically when running the Vaadin project.

--- a/documentation/ccdm/quick-start-guide.asciidoc
+++ b/documentation/ccdm/quick-start-guide.asciidoc
@@ -25,15 +25,16 @@ If you prefer to create a Maven project manually, check the <<preparing-a-projec
 import {Router} from '@vaadin/router';
 const router = new Router(document.querySelector('#outlet'));
 const {serverSideRoutes} = new Flow({
-  imports: () => import('../target/frontend/generated-flow-imports.js')
+  imports: () => import('../target/frontend/generated-flow-imports')
 });
 
 router.setRoutes([
   {
     path: '/help',
     component: 'app-help',
-    action: () => import('app-help.js')
+    action: () => import('app-help')
   },
+  // pass all unmatched paths to server-side
   ...serverSideRoutes
 ]);
 ----
@@ -90,7 +91,7 @@ public class ServerView extends Div {
 $ npm install --save @vaadin/router
 ----
 
-→ *Step 0b* - Create `frontend/index.html` and `frontend/index.js` to enable <<client-side-routing#,client-side routing>>.
+→ *Step 0b* - Create `frontend/index.html` and `frontend/index.ts` to enable <<client-side-routing#,client-side routing>>.
 
 .frontend/index.html
 [source, html]
@@ -113,9 +114,6 @@ router.setRoutes([
 ]);
 ----
 
-[NOTE]
-You can use <<typescript-support#,TypeScript>> in your project if you'd rather it.
-
 → *Step 0c* - Import Flow module to enable <<../routing/tutorial-routing-annotation#,server-side routing>>
 
 .frontend/index.ts
@@ -126,10 +124,11 @@ import {Flow} from '@vaadin/flow-frontend/Flow';
 
 const router = new Router(document.querySelector('#outlet'));
 const {serverSideRoutes} = new Flow({
-  imports: () => import('../target/frontend/generated-flow-imports.js')
+  imports: () => import('../target/frontend/generated-flow-imports')
 });
 
 router.setRoutes([
+  // pass all unmatched paths to server-side
   ...serverSideRoutes
 ]);
 ----

--- a/documentation/ccdm/typescript-support.asciidoc
+++ b/documentation/ccdm/typescript-support.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: TypeScript Support
-order: 3
+order: 40
 layout: page
 ---
 
@@ -9,7 +9,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = TypeScript Support
 
-Vaadin 15+ supports link:https://www.typescriptlang.org/[TypeScript] for writing client-side code, without needing any additional configuration. That includes live reloading at the development time, and optimized builds for production.
+Vaadin 15+ supports link:https://www.typescriptlang.org/[TypeScript^] for writing client-side code, without needing any additional configuration. That includes live reloading at the development time, and optimized builds for production.
 
 In order to write the app bootstrapping code, or create views in TypeScript make sure that:
 
@@ -22,7 +22,7 @@ After that any `.ts` file imported from `index.ts` (statically or dynamically) i
 = Bootstrapping with TypeScript
 
 The entry point to the application can be written in TypeScript: using an `index.ts` file is supported as well as using `index.js`. Below is a sample `index.ts` file that adds a button click listener to load the full Vaadin application lazily, only after the button is clicked.
-See the <<client-side-bootstrapping, Client-side Bootstrapping>> page for details on starting a Vaadin application from client-side code.
+See the <<client-side-bootstrapping#, Client-side Bootstrapping>> page for details on starting a Vaadin application from client-side code.
 
 .frontend/index.ts
 [source,typescript]
@@ -66,7 +66,7 @@ With the above snippets, the bootstrap page shows "Hello, World!" text with a bu
 
 = Adding a TypeScript View
 
-Since version 15 Vaadin allows defining routes and creating views in client-side code using the <<client-side-routing, Client-side routing>> approach.
+Since version 15 Vaadin allows defining routes and creating views in client-side code using the <<client-side-routing#, Client-side routing>> approach.
 Client-side views can be created in TypeScript, like in the following example:
 
 .frontend/my-view.ts
@@ -150,8 +150,8 @@ const router = new Router(document.querySelector('#outlet'));
 router.setRoutes(routes);
 ----
 
-Now `my-view` is accessible via the root path, i.e. `http://localhost:8080/`. All the other routes are handled by the server-side router. See the <<client-side-routing, Client-side Routing>> page for more information.
+Now `my-view` is accessible via the root path, i.e. `http://localhost:8080/`. All the other routes are handled by the server-side router. See the <<client-side-routing#, Client-side Routing>> page for more information.
 
 = Limitations
 
-TypeScript support does not apply to <<polymer-templates/tutorial-template-intro, Polymer-based declarative HTML templates>>.
+TypeScript support does not apply to <<../polymer-templates/tutorial-template-intro#, Polymer-based declarative HTML templates>>.

--- a/documentation/cdi/tutorial-cdi-events.asciidoc
+++ b/documentation/cdi/tutorial-cdi-events.asciidoc
@@ -35,12 +35,12 @@ public class BootstrapCustomizer {
 
     private void onServiceInit(@Observes
             ServiceInitEvent serviceInitEvent) {
-        serviceInitEvent.addClientIndexBootstrapListener(
+        serviceInitEvent.addIndexHtmlRequestListener(
                 this::modifyBootstrapPage);
     }
 
     private void modifyBootstrapPage(
-            ClientIndexBootstrapPage response) {
+            IndexHtmlResponse response) {
         response.getDocument().body().append(
                 "<p>By CDI add-on</p>");
     }

--- a/documentation/migration/3-general-differences.asciidoc
+++ b/documentation/migration/3-general-differences.asciidoc
@@ -63,7 +63,7 @@ This is not necessary anymore, and in Vaadin 10+ the UI content is delivered on 
 
 If you had previously customized the initial response with `BootstrapListener`, using client-side bootstrapping with `index.html` template is a simpler way of customizing the initial page response by adding the content directly to the file.
 
-`ClientIndexBootstrapListener` is still there and can be registered using a `VaadinServiceInitListener`, as shown by <<../advanced/tutorial-service-init-listener#,this tutorial>>.
+`IndexHtmlRequestListener` is still there and can be registered using a `VaadinServiceInitListener`, as shown by <<../advanced/tutorial-service-init-listener#,this tutorial>>.
 
 == Configuring Server Push
 

--- a/documentation/src/main/html/ccdm/ClientSideBootstrapping.html
+++ b/documentation/src/main/html/ccdm/ClientSideBootstrapping.html
@@ -5,7 +5,8 @@ tutorial::ccdm/client-side-bootstrapping.asciidoc
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Polyfills for the Web Component APIs are required to use Web Components
-    in the browsers that do not support these APIs natively (e.g. IE11) -->
+    in the browsers that do not support these APIs natively (e.g. MS Edge) -->
+
   <script src="./VAADIN/build/webcomponentsjs/webcomponents-loader.js" defer></script>
   <!-- index.ts is included here automatically (either by the dev server or during the build) -->
 </head>

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/advanced/VaadinServiceInitListenerPage.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/advanced/VaadinServiceInitListenerPage.java
@@ -12,8 +12,8 @@ public class VaadinServiceInitListenerPage {
 
         @Override
         public void serviceInit(ServiceInitEvent event) {
-            event.addClientIndexBootstrapListener(response -> {
-                // ClientIndexBootstrapListener to change the bootstrap page
+            event.addIndexHtmlRequestListener(response -> {
+                // IndexHtmlRequestListener to change the bootstrap page
             });
 
             event.addDependencyFilter((dependencies, filterContext) -> {

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
@@ -18,19 +18,19 @@ package com.vaadin.flow.tutorial.ccdm;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
-import com.vaadin.flow.server.ClientIndexBootstrapListener;
-import com.vaadin.flow.server.ClientIndexBootstrapPage;
+import com.vaadin.flow.server.IndexHtmlRequestListener;
+import com.vaadin.flow.server.IndexHtmlResponse;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("ccdm/client-side-bootstrapping.asciidoc")
 public class ClientSideBootstrapPage {
-    public class CustomBootstrapPageListener implements
-            ClientIndexBootstrapListener {
+    public class MyIndexHtmlRequestListener implements
+                IndexHtmlRequestListener {
 
         @Override
-        public void modifyBootstrapPage(
-                ClientIndexBootstrapPage clientIndexBootstrapPage) {
-            Document document = clientIndexBootstrapPage.getDocument();
+        public void modifyIndexHtmlResponse(
+                IndexHtmlResponse indexHtmlResponse) {
+            Document document = indexHtmlResponse.getDocument();
 
             Element head = document.head();
 

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/ccdm/ClientSideBootstrapPage.java
@@ -18,14 +18,14 @@ package com.vaadin.flow.tutorial.ccdm;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
-import com.vaadin.flow.server.IndexHtmlRequestListener;
-import com.vaadin.flow.server.IndexHtmlResponse;
+import com.vaadin.flow.server.communication.IndexHtmlRequestListener;
+import com.vaadin.flow.server.communication.IndexHtmlResponse;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 @CodeFor("ccdm/client-side-bootstrapping.asciidoc")
 public class ClientSideBootstrapPage {
     public class MyIndexHtmlRequestListener implements
-                IndexHtmlRequestListener {
+            IndexHtmlRequestListener {
 
         @Override
         public void modifyIndexHtmlResponse(

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/cdi/Events.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/cdi/Events.java
@@ -15,8 +15,8 @@
  */
 package com.vaadin.flow.tutorial.cdi;
 
-import com.vaadin.flow.server.ClientIndexBootstrapPage;
 import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.communication.IndexHtmlResponse;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
 
 import javax.enterprise.event.Observes;
@@ -28,12 +28,12 @@ public class Events {
 
         private void onServiceInit(@Observes
                 ServiceInitEvent serviceInitEvent) {
-            serviceInitEvent.addClientIndexBootstrapListener(
+            serviceInitEvent.addIndexHtmlRequestListener(
                     this::modifyBootstrapPage);
         }
 
         private void modifyBootstrapPage(
-                ClientIndexBootstrapPage response) {
+                IndexHtmlResponse response) {
             response.getDocument().body().append(
                     "<p>By CDI add-on</p>");
         }


### PR DESCRIPTION
*fix: broken links and headers*
 - Purely a technical change to make sure links work as expected, and section headers use consequent levels: L1 > L2.

*fix: remove mentions of CCDM*
 - Make the page title consistent with the entry in the table of contents in https://github.com/vaadin/vaadin-docs/blob/9397b105a7c12fece0106a2172582ecf270df599/website/_data/docs.yml#L10

*fix: copy-edit the client-side bootstrapping page*
 - wording
 - typos
 - update the `IndexHtmlRequestListener` class name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/842)
<!-- Reviewable:end -->
