### PR TITLE
fix: typo in the sample code snippet

### DIFF
--- a/documentation/ccdm/client-side-bootstrapping.asciidoc
+++ b/documentation/ccdm/client-side-bootstrapping.asciidoc
@@ -89,8 +89,8 @@ If the `index.html` or `index.ts` (and `index.js`) files in the frontend folder 
 import { Flow } from '@vaadin/flow-frontend/Flow';
 
 const flow = new Flow({
-  // relative path to `projectDir/target/frontend/flow-generated-imports.js`
-  imports: () => import('../target/frontend/flow-generated-imports.js')
+  // relative path to `projectDir/target/frontend/generated-flow-imports.js`
+  imports: () => import('../target/frontend/generated-flow-imports.js')
 });
 
 // load Flow and let it take full control over the browser page


### PR DESCRIPTION
should be `generated-flow-imports.js`, but was `flow-generated-imports.js`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/879)
<!-- Reviewable:end -->
