### PR TITLE
CCDM: change to 'TypeScript support' to 'Intro to TypeScript'

### DIFF
--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -106,7 +106,7 @@ The Vaadin Flow documentation is arranged in the following sections and we recom
 * <<ccdm/quick-start-guide-v14#, Migrate a V14 project>>
 * <<ccdm/client-side-bootstrapping#, Client-side Bootstrapping>>
 * <<ccdm/client-side-routing#, Client-side Routing>>
-* <<ccdm/typescript-support#, TypeScript Support>>
+* <<ccdm/intro-to-typescript-in-v15#, Intro to TypeScript in Vaadin 15>>
 * <<ccdm/how-to-create-api-endpoint#, How to Create an API Endpoint>>
 * <<ccdm/how-to-access-backend-from-typescript#, How to Access the Backend from TypeScript>>
 * <<ccdm/client-side-security#, Security in client-side>>

--- a/documentation/ccdm/how-to-access-backend-from-typescript.asciidoc
+++ b/documentation/ccdm/how-to-access-backend-from-typescript.asciidoc
@@ -8,7 +8,7 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 = How to Access the Backend from TypeScript
 
-Vaadin Connect generates TypeScript clients for calling the Java backend
+Vaadin 15 generates TypeScript clients for calling the Java backend
 in a type-checkable way.
 
 [WARNING]

--- a/documentation/ccdm/intro-to-typescript-in-v15.asciidoc
+++ b/documentation/ccdm/intro-to-typescript-in-v15.asciidoc
@@ -1,12 +1,12 @@
 ---
-title: TypeScript Support
+title: Intro to TypeScript in Vaadin 15
 order: 40
 layout: page
 ---
 
 ifdef::env-github[:outfilesuffix: .asciidoc]
 
-= TypeScript Support
+= Intro to TypeScript in Vaadin 15
 
 Vaadin 15+ supports link:https://www.typescriptlang.org/[TypeScript^] for writing client-side code, without needing any additional configuration. That includes live reloading at the development time, and optimized builds for production.
 
@@ -24,7 +24,7 @@ After that any `.ts` file imported from `index.ts` (statically or dynamically) i
 
 = Bootstrapping with TypeScript
 
-The entry point to the application can be written in TypeScript: using an `index.ts` file is supported as well as using `index.js`. Below is a sample `index.ts` file that adds a button click listener to load the full Vaadin application lazily, only after the button is clicked.
+Vaadin 15 introduces a new bootstrapping mode where the bootstrap template (`index.html`) and application entry point are readily available for customization. The entry point to the application can be written in TypeScript: using an `index.ts` file is supported as well as using `index.js`. Below is a sample `index.ts` file that adds a button click listener to load the full Vaadin application lazily, only after the button is clicked.
 See the <<client-side-bootstrapping#, Client-side Bootstrapping>> page for details on starting a Vaadin application from client-side code.
 
 .frontend/index.ts
@@ -154,6 +154,10 @@ router.setRoutes(routes);
 ----
 
 Now `my-view` is accessible via the root path, i.e. `http://localhost:8080/`. All the other routes are handled by the server-side router. See the <<client-side-routing#, Client-side Routing>> page for more information.
+
+= Accessing Backend Data in TypeScript Views
+
+Vaadin 15 provides a type-safe and secured way to access data from backend in frontend views using the generated TypeScript code. During the development time, Vaadin scans the backend code and generates TypeScript code which can call corresponding Java methods. The generated code are processed through the same build chain as other TypeScript views. So that only necessary code are bundled for your application in production mode. See <<how-to-create-api-endpoint#, How to Create API Endpoint>> and <<how-to-access-backend-from-typescript#, How to Access the Backend from TypeScript>> for more information.
 
 = Limitations
 

--- a/documentation/src/main/html/ccdm/index-for-typescript-1.html
+++ b/documentation/src/main/html/ccdm/index-for-typescript-1.html
@@ -1,4 +1,4 @@
-tutorial::ccdm/typescript-support.asciidoc
+tutorial::ccdm/intro-to-typescript-in-v15.asciidoc
 
 <!DOCTYPE html>
 <html lang="en">

--- a/documentation/src/main/html/ccdm/index-for-typescript-2.html
+++ b/documentation/src/main/html/ccdm/index-for-typescript-2.html
@@ -1,4 +1,4 @@
-tutorial::ccdm/typescript-support.asciidoc
+tutorial::ccdm/intro-to-typescript-in-v15.asciidoc
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Fixes vaadin/flow#6880
* Change the page from TS support to 'intro to TS'
* Add a brief introduction for new bootstrap mode
* Add a short reference for connect service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/909)
<!-- Reviewable:end -->
