### PR TITLE
fix: improve the Quick Start and Migrating from Vaadin 14 pages

### DIFF
--- a/documentation/src/main/java/com/vaadin/flow/tutorial/typescript/UpgradingFromVaadin14Guide.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/typescript/UpgradingFromVaadin14Guide.java
@@ -17,17 +17,15 @@ package com.vaadin.flow.tutorial.typescript;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.tutorial.annotations.CodeFor;
-import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.notification.Notification;
 
 
-@CodeFor("typescript/quick-start-guide.asciidoc")
-public class QuickStartGuide {
-    @Route("server")
-    public class ServerView extends Div {
-        public ServerView() {
-            this.add(new Button("click-me", e -> Notification.show("clicked")));
-        }
+@CodeFor("typescript/upgrading-from-vaadin14.asciidoc")
+public class UpgradingFromVaadin14Guide {
+    @Route(value = "dashboard"/*, layout = MainView.class <-- remove this */)
+    @RouteAlias(value = ""/*, layout = MainView.class <-- and this */)
+    public class DashboardView extends Div {
+
     }
 }

--- a/documentation/typescript/quick-start-guide.asciidoc
+++ b/documentation/typescript/quick-start-guide.asciidoc
@@ -69,13 +69,13 @@ import '@vaadin/vaadin-button/vaadin-button';
 @customElement('app-help')
 export class AppHelp extends LitElement {
     render() {
-        return html`
+      return html`
         <vaadin-button @click=${this.onClick}>Read More</vaadin-button>
       `;
     }
 
     onClick() {
-        console.log('clicked');
+      console.log('clicked');
     }
 }
 ----

--- a/documentation/typescript/quick-start-guide.asciidoc
+++ b/documentation/typescript/quick-start-guide.asciidoc
@@ -52,7 +52,7 @@ router.setRoutes([
   {
     path: '/help',
     component: 'app-help',
-    action: () => import('./views/help/app-help')
+    action: async () => { await import('./views/help/app-help'); }
   },
   ...
 ]);
@@ -64,17 +64,18 @@ Second create a new client-side view:
 [source, typescript]
 ----
 import {LitElement, html, customElement} from 'lit-element';
+import '@vaadin/vaadin-button/vaadin-button';
 
 @customElement('app-help')
 export class AppHelp extends LitElement {
     render() {
-      return html`
-        <vaadin-button @click=${this.click}>Read More</vaadin-button>
+        return html`
+        <vaadin-button @click=${this.onClick}>Read More</vaadin-button>
       `;
     }
 
-    click(e) {
-      console.log('clicked');
+    onClick() {
+        console.log('clicked');
     }
 }
 ----

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -10,6 +10,10 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 We recommend the following steps to upgrade an existing Vaadin 14 application to Vaadin 15, and then to add a TypeScript view to it.
 
+[TIP]
+You can use JavaScript instead of TypeScript if you prefer.
+JavaScript is supported as well: any `.ts` file can be replaced with a `.js` alternative.
+
 * change the Vaadin version in `pom.xml` (<<upgrading-from-vaadin14#step-1,step 1>>)
 * (for Spring-based apps) use a compatible version of Spring  (<<upgrading-from-vaadin14#step-1b,step 1b>>)
 * build the app to see if it uses any APIs deprecated in Vaadin 15

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -20,7 +20,8 @@ JavaScript is supported as well: any `.ts` file can be replaced with a `.js` alt
 * create a custom index page for client-side bootstrapping  (<<upgrading-from-vaadin14#step-2,step 2>>)
 * add a dependency to `lit-element` to create UIs in TypeScript (<<upgrading-from-vaadin14#step-3,step 3>>)
 * add a TypeScript page layout (<<upgrading-from-vaadin14#step-4,step 4>>)
-* add a TypeScript view (<<upgrading-from-vaadin14#step-5,step 5>>)
+* move the existing Java views into the TypeScript page layout (<<upgrading-from-vaadin14#step-5,step 5>>)
+* add a TypeScript view (<<upgrading-from-vaadin14#step-6,step 6>>)
 
 _If you are starting a new app with Vaadin 15, please check the <<quick-start-guide#,Quick Start Guide>>._
 
@@ -138,6 +139,7 @@ export class MainLayoutElement extends LitElement {
     return css`
       :host {
         display: block;
+        height: 100%;
       }
     `;
   }
@@ -176,5 +178,22 @@ const routes = [
 ----
 
 
-== Step 5 - Add a TypeScript view [[step-5]]
+== Step 5 - Move the existing Java views into the TypeScript page layout [[step-5]]
+
+This step is needed if you want to display your existing Java views in the same page layout with the new TypeScript views.
+In order to move an existing Java view from a parent layout defined in Java into a parent layout defined in TypeScript, you need to change the `@Route()` annotation on the Java view and remove the `layout` property from it:
+
+For example, for a Java view defined in a `DashboardView` class the change would look like this:
+
+.DashboardView.java
+[source, java]
+----
+@Route(value = "dashboard"/*, layout = MainView.class <-- remove this */)
+@RouteAlias(value = ""/*, layout = MainView.class <-- and this */)
+public class DashboardView extends Div {
+    ...
+}
+----
+
+== Step 6 - Add a TypeScript view [[step-6]]
 Continue with the <<quick-start-guide#step-3,Quick Start Guide - Step 3>> to see how.

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -106,7 +106,7 @@ There are other ways to create UI in TypeScript, but they are not covered in thi
 
 [source,bash]
 ----
-$ npm install --save lit-element
+$ npx pnpm install --save lit-element
 ----
 
 

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -104,9 +104,10 @@ cp target/index.html target/index.ts frontend
 This step is needed if you want to create TypeScript views using LitElement as a helper library.
 There are other ways to create UI in TypeScript, but they are not covered in this guide.
 
+Run in the console, in the project folder:
 [source,bash]
 ----
-$ npx pnpm install --save lit-element
+npx pnpm install --save lit-element
 ----
 
 

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -23,22 +23,42 @@ _If you are starting a new app with Vaadin 15, please check the <<quick-start-gu
 
 == Step 1 - Make your project depend on Vaadin 15 [[step-1]]
 
+Edit the `pom.xml` file and change the versions of the Vaadin platform dependency and the Vaadin Maven plugin to Vaadin 15:
+
 .pom.xml
 [source,xml]
 ----
+<properties>
+    ...
+    <!-- See the latest version at
+         https://github.com/vaadin/platform/releases -->
+    <vaadin.version>15.0.0.alpha11</vaadin.version>
+    ...
+</properties>
+
 <dependencyManagement>
     <dependencies>
+        <!-- add the Vaadin platform to the class-path -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-bom</artifactId>
-            <!-- See the latest version at
-                 https://github.com/vaadin/platform/releases -->
-            <version>15.0.0.alpha8</version>
+            <version>${vaadin.version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
     </dependencies>
 </dependencyManagement>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-maven-plugin</artifactId>
+            <version>${vaadin.version}</version>
+            ...
+        </plugin>
+    </plugins>
+</build>
 ----
 
 [NOTE]

--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -43,7 +43,7 @@ Edit the `pom.xml` file and change the versions of the Vaadin platform dependenc
 
 <dependencyManagement>
     <dependencies>
-        <!-- add the Vaadin platform to the class-path -->
+        <!-- add the Vaadin platform to the classpath -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-bom</artifactId>


### PR DESCRIPTION
**Upgrading from Vaadin 14**
* fix: mention Vaadin Maven plugin
   Explicitly mention that the plugin version needs to be changed as well, so that the project uses matching versions of the Vaadin platform and the Vaadin Maven plugin.
* fix: replace npm with pnpm
   This is needed after `pnpm` became the default front-end package manager in Vaadin apps (see vaadin/flow#6966)
* fix: clarify where to run the `pnpm install` command
* fix: add a tip that JS is supported as well as TS
* fix: add a step to move existing Java views into a TS page layout

**Quick Start Guide**
* fix: avoid TS compilation errors in code snippets
   - the `route.action` property does not allow returning a promise of a particular ES module, thus `action: () => import('./views/help/app-help')` does not pass the type check
   - the `click()` method in the snippet overrides the `HTMLElement`'s `click` property, which is not intended
* fix: add an import for the `vaadin-button` custom element used in a code snippet

This addresses comments from the recent DX tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/970)
<!-- Reviewable:end -->
