### PR TITLE
Remove a statement regarding client-side security

### DIFF
--- a/documentation/typescript/configuring-security.asciidoc
+++ b/documentation/typescript/configuring-security.asciidoc
@@ -10,8 +10,6 @@ ifdef::env-github[:outfilesuffix: .asciidoc]
 
 When developing server-side views, service access control is done by using regular java approaches: servlet-container based security, third party libraries, or session based solutions.
 
-On the other hand, client-side views do not have any sort of security, hence, it is necessary to secure the endpoint services that they access.
-
 This article describes all the pieces needed for securing client centric applications.
 
 == How to secure server-side endpoints


### PR DESCRIPTION
Remove the “client-side views do not have any sort of security” statement, as it should be possible to restrict access to assets for unauthenticated users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1004)
<!-- Reviewable:end -->
