### PR TITLE
Fix typo in PWA doc

### DIFF
--- a/documentation/pwa/tutorial-pwa-icons.asciidoc
+++ b/documentation/pwa/tutorial-pwa-icons.asciidoc
@@ -15,7 +15,7 @@ Vaadin uses and serves default PWA icons automatically, but you can use a custom
 
 To use a custom icon image:
 
-. Create an icon image named `ìcon.png`. The icon must be in PNG format. 
+. Create an icon image named `icon.png`. The icon must be in PNG format. 
 . Add the image to your `src/main/webapp/icons/` folder. 
 
 Vaadin automatically scans for an image named `icon.png` in the `*/icons*` folder in the `webapp` resources folder. It uses this image to create appropriately-sized images for different devices. If no icon is found, the default image is used as a fallback. 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1023)
<!-- Reviewable:end -->
