### PR TITLE
remove-default-generate-polyfills

### DIFF
--- a/documentation/src/main/html/typescript/StartingTheApp.html
+++ b/documentation/src/main/html/typescript/StartingTheApp.html
@@ -4,9 +4,6 @@ tutorial::typescript/starting-the-app.asciidoc
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Polyfills for the Web Component APIs are required to use Web Components
-     in the browsers that do not support these APIs natively (e.g. MS Edge) -->
-  <script src="./VAADIN/build/webcomponentsjs/webcomponents-loader.js" defer></script>
   <style>
     body, #outlet {
       height: 100vh;

--- a/documentation/typescript/starting-the-app.asciidoc
+++ b/documentation/typescript/starting-the-app.asciidoc
@@ -78,9 +78,6 @@ If the `index.html` or `index.ts` files in the frontend folder are missing, `vaa
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Polyfills for the Web Component APIs are required to use Web Components
-     in the browsers that do not support these APIs natively (e.g. MS Edge) -->
-  <script src="./VAADIN/build/webcomponentsjs/webcomponents-loader.js" defer></script>
   <style>
     body, #outlet {
       height: 100vh;


### PR DESCRIPTION
default generated polyfills for index.html example also needs to be removed in doc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1061)
<!-- Reviewable:end -->
