### PR TITLE
use `npm` instead of `pnpm` in the docs for V15

### DIFF
--- a/documentation/typescript/upgrading-from-vaadin14.asciidoc
+++ b/documentation/typescript/upgrading-from-vaadin14.asciidoc
@@ -114,7 +114,7 @@ There are other ways to create UI in TypeScript, but they are not covered in thi
 Run in the console, in the project folder:
 [source,bash]
 ----
-npx pnpm install --save lit-element
+npm install --save lit-element
 ----
 
 


### PR DESCRIPTION
the default is `npm`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1094)
<!-- Reviewable:end -->
