### PR TITLE
Document new servlet parameter maxMessageSuspendTimeout (#1120)

### DIFF
--- a/documentation/advanced/tutorial-all-vaadin-properties.asciidoc
+++ b/documentation/advanced/tutorial-all-vaadin-properties.asciidoc
@@ -69,6 +69,16 @@ Returns whether the sending of URL's as GET and POST parameters in requests with
 When using the long polling transport strategy,  it specifies how long it accepts responses after
 each network request. Number of milliseconds.
 
+|maxMessageSuspendTimeout |
+In certain cases, such as when the server sends adjacent `XmlHttpRequest` responses and push
+messages over a low bandwidth connection, messages may be received out of order by the client.
+This property specifies the maximum time (in milliseconds) that the client will then wait for
+the predecessors of a received out-order message, before considering them missing and requesting
+a full resynchronization of the application state from the server. The default value is 5000 ms.
+You may increase this if your application exhibits an undue amount of resynchronization requests
+(as these degrade the UX due to flickering and loss of client-side-only state such as scroll
+position).
+
 |load.es5.adapters |
 Include polyfills for browsers that do not support ES6 to their initial page. In order for
 web components to work, extra libraries (polyfills) are required to be loaded, can be turned off


### PR DESCRIPTION
Cherry-picked from master. Not to be merged until release of Flow 2.1.6 / Vaadin 14.1.19.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1121)
<!-- Reviewable:end -->
