### PR TITLE
Fix someUI in documents with UI.getCurrent()

### DIFF
--- a/documentation/browser/tutorial-flow-window-resize.asciidoc
+++ b/documentation/browser/tutorial-flow-window-resize.asciidoc
@@ -12,7 +12,7 @@ The `Page` class allows you to register a listener for events that affect the we
 
 [source,java]
 ----
-Page page = someUI.getPage();
+Page page = UI.getCurrent().getPage();
 page.addBrowserWindowResizeListener(
         event -> Notification.show("Window width="
                 + event.getWidth()

--- a/documentation/src/main/java/com/vaadin/flow/tutorial/browser/Listeners.java
+++ b/documentation/src/main/java/com/vaadin/flow/tutorial/browser/Listeners.java
@@ -24,8 +24,7 @@ import com.vaadin.flow.tutorial.annotations.CodeFor;
 public class Listeners {
 
     public void addResizeListener() {
-        UI someUI = null;
-        Page page = someUI.getPage();
+        Page page = UI.getCurrent().getPage();
         page.addBrowserWindowResizeListener(
                 event -> Notification.show("Window width="
                         + event.getWidth()


### PR DESCRIPTION
Fix  https://github.com/vaadin/90min-dx-tasks/issues/130

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1146)
<!-- Reviewable:end -->
