### PR TITLE
Upgrade the minimum required Jetty version (#1151)

### DIFF
--- a/documentation/production/tutorial-jetty.asciidoc
+++ b/documentation/production/tutorial-jetty.asciidoc
@@ -52,7 +52,7 @@ To be able to deploy and run applications with it, it is only needed to add the 
         <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
-            <version>9.4.15.v20190215</version>
+            <version>9.4.27.v20200227</version>
             <configuration>
                 <scanIntervalSeconds>2</scanIntervalSeconds>
             </configuration>

--- a/documentation/workflow/tutorial-plain-servlet-live-reload.asciidoc
+++ b/documentation/workflow/tutorial-plain-servlet-live-reload.asciidoc
@@ -28,6 +28,10 @@ is applied including changes made to a custom component (`PolymerTemplate` subcl
 
 During those changes the session is not preserved.
 
+[NOTE]
+We recommend you to use Jetty Maven Plugin `9.4.27.v20200227` or a higher version.
+There is a known issue in the previous versions that causes `RouteNotFoundException` when trying to reload Java changes automatically.
+
 === JRebel
 
 JRebel tool only applies changes in the binaries, as a result:


### PR DESCRIPTION
* Upgrade Jetty version

* Add a note about the minimum version of Jetty in live-reload doc

(cherry picked from commit 3f4a1c21d4c82dc2d1c6453b941404ddc8130455)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1153)
<!-- Reviewable:end -->
