### PR TITLE
Fixed AsciiDoc verification failing with block image markup (#1191).

### DIFF
--- a/documentation/src/test/java/com/vaadin/flow/tutorial/TestTutorialCodeCoverage.java
+++ b/documentation/src/test/java/com/vaadin/flow/tutorial/TestTutorialCodeCoverage.java
@@ -87,7 +87,7 @@ public class TestTutorialCodeCoverage {
                 new CodeFileChecker(HTML_BLOCK_IDENTIFIER,
                         gatherWebFilesCode("html", HTML_LOCATION, TUTORIAL_BINDER_WITH_TEMPLATES_HTML_LOCATION)),
                 new AsciiDocLinkWithDescriptionChecker("image:",
-                        Pattern.compile("image:(.*?)\\[(.*?)]")),
+                        Pattern.compile("image::?(.*?)\\[(.*?)]")),
                 new AsciiDocLinkWithDescriptionChecker("#,",
                         Pattern.compile("<<(.*?)#,(.*?)>>"),
                         ASCII_DOC_EXTENSION));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1192)
<!-- Reviewable:end -->
