### PR TITLE
Remove leading slash in path

### DIFF
--- a/documentation/typescript/creating-routes.asciidoc
+++ b/documentation/typescript/creating-routes.asciidoc
@@ -35,7 +35,7 @@ export const router = new Router(document.querySelector('#outlet'));
 router.setRoutes([
   // client-side views
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   },
   // pass all unmatched paths to server-side
@@ -87,7 +87,7 @@ const {serverSideRoutes} = new Flow({
 router.setRoutes([
   // client-side views
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   },
   // pass all unmatched paths to server-side
@@ -136,11 +136,11 @@ Vaadin Router goes through the routes until the first match is found, then it cr
 ----
 router.setRoutes([
   {
-    path: '/help',
+    path: 'help',
     component: 'app-help',
   },
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   }
 ]);
@@ -181,15 +181,15 @@ Vaadin Router allows to group related routes together under a common parent by u
 ----
 router.setRoutes([
   {
-    path: '/',
+    path: '',
     component: 'app-layout'
     children: [
       {
-        path: '/help',
+        path: 'help',
         component: 'app-help',
       },
       {
-        path: '/categories',
+        path: 'categories',
         component: 'app-categories'
       }
     ]
@@ -251,7 +251,7 @@ import {Router} from '@vaadin/router';
 export const router = new Router(document.querySelector('#outlet'));
 router.setRoutes([
   {
-    path: '/view1',
+    path: 'view1',
     component: 'my-view'
   }
 ]);

--- a/documentation/typescript/quick-start-guide.asciidoc
+++ b/documentation/typescript/quick-start-guide.asciidoc
@@ -54,7 +54,7 @@ First add a new route for the new view:
 router.setRoutes([
   ...
   {
-    path: '/help',
+    path: 'help',
     component: 'app-help',
     action: async () => { await import('./views/help/app-help'); }
   },

--- a/documentation/v15-migration/prepare-to-add-ts-views.asciidoc
+++ b/documentation/v15-migration/prepare-to-add-ts-views.asciidoc
@@ -89,7 +89,7 @@ import './main-layout';
 
 const routes = [
     {
-    path: '/',
+    path: '',
     component: 'main-layout',
     children: [
       // add you client-side views here, e.g.

--- a/documentation/v15-migration/upgrading-from-vaadin14.asciidoc
+++ b/documentation/v15-migration/upgrading-from-vaadin14.asciidoc
@@ -57,11 +57,6 @@ Edit the `pom.xml` file and change the versions of the Vaadin platform dependenc
 
 You can check out these two reference pom files: link:https://github.com/vaadin/skeleton-starter-flow/blob/master/pom.xml[one for a Vanilla Vaadin project], link:https://github.com/vaadin/skeleton-starter-flow-spring/blob/master/pom.xml[the other for a Vaadin Spring project].
 
-[NOTE]
-Vaadin 15 includes several breaking API changes, mainly related to application bootstrapping and the bootstrap page configuration.
-If you see Java deprecation warnings during the build, check the <<migrating-from-vaadin-10-14,Migration>> section in the *Client-side bootstrapping page*.
-
-
 == Step 2 - Update Spring (for Spring-based projects) [[step-2]]
 
 Vaadin works with <<../spring/tutorial-spring-basic#,Spring Boot>> or <<../spring/tutorial-spring-basic-mvc#,Spring MVC>>.
@@ -93,6 +88,6 @@ public class AppShell implements AppShellConfigurator {
 see <<../advanced/tutorial-modifying-the-bootstrap-page#java-annotations, set of annotations to modify the Bootstrap page>> for more details.
 
 
-These three steps might be all you need to follow to upgrade from Vaadin 14 to Vaadin 15 if you didn't use the deprecated APIs, in case you use some of those, check <<api-breaking-changes-from-vaadin14, the API breaking changes>> to see how to migrate them.
+These three steps might be all you need to follow to upgrade from Vaadin 14 to Vaadin 15 if you didn't use the deprecated APIs, in case you use some of those, check <<breaking-api-changes-in-v15#, the API breaking changes>> to see how to migrate them.
 
 At this point your app is running on Vaadin 15, and you can start using any of it's link:https://vaadin.com/releases/vaadin-15[new features], including TypeScript views. Follow the <<prepare-to-add-ts-views, getting started with TypeScript views>> guide to see how to add TypeScript views to your existing app. With TypeScript you can add views that work without a constant connection to the server, and have direct access to the native Web platform features, such as Service Workers, File System API, and more.


### PR DESCRIPTION
In the doc, the path is like `path: '/help'`, in the project generated by starter wizard, it doesn't have the slash, i.e. `path: 'help'`. 

So this PR is to remove the leading slash to make it more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1205)
<!-- Reviewable:end -->
