### PR TITLE
Remove leading slash in path

### DIFF
--- a/documentation/typescript/creating-routes.asciidoc
+++ b/documentation/typescript/creating-routes.asciidoc
@@ -35,7 +35,7 @@ export const router = new Router(document.querySelector('#outlet'));
 router.setRoutes([
   // client-side views
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   },
   // pass all unmatched paths to server-side
@@ -87,7 +87,7 @@ const {serverSideRoutes} = new Flow({
 router.setRoutes([
   // client-side views
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   },
   // pass all unmatched paths to server-side
@@ -136,11 +136,11 @@ Vaadin Router goes through the routes until the first match is found, then it cr
 ----
 router.setRoutes([
   {
-    path: '/help',
+    path: 'help',
     component: 'app-help',
   },
   {
-    path: '/categories',
+    path: 'categories',
     component: 'app-categories'
   }
 ]);
@@ -181,15 +181,15 @@ Vaadin Router allows to group related routes together under a common parent by u
 ----
 router.setRoutes([
   {
-    path: '/',
+    path: '',
     component: 'app-layout'
     children: [
       {
-        path: '/help',
+        path: 'help',
         component: 'app-help',
       },
       {
-        path: '/categories',
+        path: 'categories',
         component: 'app-categories'
       }
     ]
@@ -251,7 +251,7 @@ import {Router} from '@vaadin/router';
 export const router = new Router(document.querySelector('#outlet'));
 router.setRoutes([
   {
-    path: '/view1',
+    path: 'view1',
     component: 'my-view'
   }
 ]);

--- a/documentation/typescript/quick-start-guide.asciidoc
+++ b/documentation/typescript/quick-start-guide.asciidoc
@@ -54,7 +54,7 @@ First add a new route for the new view:
 router.setRoutes([
   ...
   {
-    path: '/help',
+    path: 'help',
     component: 'app-help',
     action: async () => { await import('./views/help/app-help'); }
   },

--- a/documentation/v15-migration/prepare-to-add-ts-views.asciidoc
+++ b/documentation/v15-migration/prepare-to-add-ts-views.asciidoc
@@ -89,7 +89,7 @@ import './main-layout';
 
 const routes = [
     {
-    path: '/',
+    path: '',
     component: 'main-layout',
     children: [
       // add you client-side views here, e.g.


### PR DESCRIPTION
In the doc, a path is like `path: '/help'`, in the project generated by starter wizard, it doesn't have the slash, i.e. `path: 'help'`.

So this PR is to remove the leading slash to make it more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1206)
<!-- Reviewable:end -->
