### PR TITLE
Document new step to setup HotswapAgent (vaadin/flow#8097)

### DIFF
--- a/documentation/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/documentation/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -15,7 +15,7 @@ Currently, Live Reload works on HotswapAgent version 1.4.1-SNAPSHOT and newer. S
 
 . Download https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[DCEVM JDK], unpack it and set `JAVA_HOME` to it's location. Alternatively, you can add the JDK to your IDE.
 . Download https://github.com/HotswapProjects/HotswapAgent/releases[HotswapAgent 1.4.1-SNAPSHOT]
-. Set your `javaagent` VM argument as such `-javaagent:<path-to-file>/hotswap-agent-1.4.1.jar`
+. Rename the downloaded HotswapAgent JAR to `hotswap-agent.jar`. Move it to the `lib/hotswap` directory of the unpacked DCEVM JDK. When prompted, replace the existing file.
 . When using an IDE, follow setup guides available in http://hotswapagent.org/
 . Depending on your project technology stack, you might have to apply <<Additional configurations>>
 . Run (or Debug) Vaadin application in Dev Mode


### PR DESCRIPTION
Fixes vaadin/flow#8097

Document new file replacement step to get the correct version of HotswapAgent on DCEVM JDK.
Remove unnecessary and outdated steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1216)
<!-- Reviewable:end -->
