### PR TITLE
Distinguish between Live Reload and Hotswap (vaadin/flow#8020)

### DIFF
--- a/documentation/Overview.asciidoc
+++ b/documentation/Overview.asciidoc
@@ -36,8 +36,8 @@ The Vaadin documentation is arranged in the following sections and we recommend 
 ** <<workflow/setup-live-reload-springboot#, Setup Live Reload using Spring Boot>>
 ** <<workflow/setup-live-reload-jrebel#, Setup Live Reload using JRebel>>
 ** <<workflow/setup-live-reload-hotswap-agent#, Setup Live Reload using HotswapAgent>>
-** <<workflow/tutorial-plain-servlet-live-reload#, Live Reload in Web Applications>>
-** <<workflow/tutorial-cdi-live-reload#, Live Reload in CDI Applications>>
+** <<workflow/tutorial-plain-servlet-hotswap#, Hotswapping in Web Applications>>
+** <<workflow/tutorial-cdi-hotswap#, Hotswapping in CDI Applications>>
 
 == Router and Navigation
 * <<routing/tutorial-routing-on-client-side-and-server-side#,Routing on Client Side and Server Side>>

--- a/documentation/workflow/setup-live-reload-springboot.asciidoc
+++ b/documentation/workflow/setup-live-reload-springboot.asciidoc
@@ -26,6 +26,12 @@ More information about Spring Boot Automatic Restart and other developer tools i
 ----
 . Run the application using `mvn spring-boot:run` or by running the `Application` class directly from your IDE
 . Navigate to your Vaadin application on the browser, make some changes, recompile and the browser will reload automatically
++
+[NOTE]
+====
+If you have some browser extension to trigger Spring Dev Tools reloads, we recommend disabling such tools as Vaadin handles reloads automatically once the server has restarted.
+Having these enabled when using Live Reload might cause unexpected behaviour.
+====
 
 == Additional configurations
 

--- a/documentation/workflow/setup-live-reload-springboot.asciidoc
+++ b/documentation/workflow/setup-live-reload-springboot.asciidoc
@@ -29,7 +29,7 @@ More information about Spring Boot Automatic Restart and other developer tools i
 +
 [NOTE]
 ====
-If you have some browser extension to trigger Spring Dev Tools reloads, we recommend disabling such tools as Vaadin handles reloads automatically once the server has restarted.
+If you have some browser extension that triggers Spring Dev Tools reloads on the browser, we recommend disabling such tools as Vaadin handles reloads automatically once the server has restarted.
 Having these enabled when using Live Reload might cause unexpected behaviour.
 ====
 

--- a/documentation/workflow/tutorial-cdi-hotswap.asciidoc
+++ b/documentation/workflow/tutorial-cdi-hotswap.asciidoc
@@ -1,12 +1,12 @@
 ---
-title: Live Reload in CDI Applications
+title: Hotswapping in CDI Applications
 order: 6
 layout: page
 ---
 
 = Hot Deploy of CDI Applications
 
-This page demonstrates how to enable live reload when developing Vaadin applications using CDI (Context and Dependency Injection,the standard dependency injection framework for Java EE).
+This page demonstrates how to enable hotswap when developing Vaadin applications using CDI (Context and Dependency Injection,the standard dependency injection framework for Java EE).
 
 == Apache TomEE
 
@@ -42,11 +42,11 @@ We assume that you are using Apache TomEE with the http://tomee.apache.org/tomee
 The configuration enables auto-reload and ensures that any change to a file with the extension `.class` (a Java recompile) triggers the TomEE server reload (you will still need to refresh the browser page).
 Note that if you base your project on the Vaadin CDI starter (from https://vaadin.com/start), the above configuration is already done for you.
 
-During the live reload cycle, the session is serialized before the server is stopped and deserialized after restarted. This means that user login and other session-based data is still available.
+During the hotswap cycle, the session is serialized before the server is stopped and deserialized after restarted. This means that user login and other session-based data is still available.
 
 === Known issues
 
-- During live reload, the TomEE log may contain warnings about memory leaks due to the webpack server and watchdog process not being terminated. These can safely be ignored.
+- During hotswap, the TomEE log may contain warnings about memory leaks due to the webpack server and watchdog process not being terminated. These can safely be ignored.
 - If a class with a `@Route` annotation is removed, the route given in the annotation is still navigable after reload. Note that this is not a problem when only modifying the route of a view, without deleting the Java class.
 
 

--- a/documentation/workflow/tutorial-plain-servlet-hotswap.asciidoc
+++ b/documentation/workflow/tutorial-plain-servlet-hotswap.asciidoc
@@ -1,10 +1,10 @@
 ---
-title: Live Reload in Plain Servlet Applications
+title: Hotswapping in Plain Servlet Applications
 order: 5
 layout: page
 ---
 
-= Live Reload in Plain Servlet Applications
+= Hotswapping in Plain Servlet Applications
 
 During application development the code changes happen frequently. There are multiple tools
 available which speed up the development process and avoid having to manually

--- a/documentation/workflow/workflow-overview.asciidoc
+++ b/documentation/workflow/workflow-overview.asciidoc
@@ -14,18 +14,15 @@ Each of these are treated in their own subtopic below.
 
 == Subtopics
 === Setup Live Reload using supported Java Hotpatching and Server restart tools
+Live Reload combines the power of established hotpatching and hotswapping technologies for Java with the ability for the browser to reload automatically, making it a perfect tool for development time.
+
 ** <<setup-live-reload-springboot#, Spring Boot Hotswapping>>
 ** <<setup-live-reload-jrebel#, JRebel>>
 ** <<setup-live-reload-hotswap-agent#, HotswapAgent class and resource redefinition>>
 
-=== Live Reload specifics when using different it in Vaadin technology stacks
-** <<tutorial-plain-servlet-live-reload#, Live Reload in Plain Servlet Applications>>
-** <<tutorial-cdi-live-reload#,Live Reload in CDI Applications>>
+Each technology supported by Live Reload is meant to be run solely. Any overlap or simultaneous use of different hotpatching technologies might cause Live Reload to misbehave.
 
-=== Run on Server in IDE
-** <<run-on-server-intellij#,Run on server in IntellJ IDEA>>
-
-== Live Reload Limitations
+==== Live Reload Limitations
 
 There are general limitations as well as some tool- or application framework-specific limitations associated with live reload.
 We cover the general limitations here; the specific limitations are covered in the subtopics.
@@ -35,3 +32,13 @@ We cover the general limitations here; the specific limitations are covered in t
 - Adding frontend resources that are connected to Java classes, such as template-based components, require a server restart as part of the live reloading.
 
 - The  <<../advanced/tutorial-preserving-state-on-refresh#,`@PreserveOnRefresh`>> annotation on a view causes the component tree to be reused when the view is refreshed in the browser; hence, any code changes to the component constructors and initializers are not reflected. To see the update, either open the view in another browser window/tab or ensure that a new instance is created in some other way.
+
+
+=== Hotswapping specifics when using it in different Vaadin technology stacks
+Hotswapping provides a way to  load changed code into a running JVM and immediately see the effects of your changes without server restarts.
+
+** <<tutorial-plain-servlet-hotswap#, Hotswapping in Plain Servlet Applications>>
+** <<tutorial-cdi-hotswap#,Hotswapping in CDI Applications>>
+
+=== Run on Server in IDE
+** <<run-on-server-intellij#,Run on server in IntellJ IDEA>>

--- a/documentation/workflow/workflow-overview.asciidoc
+++ b/documentation/workflow/workflow-overview.asciidoc
@@ -20,7 +20,8 @@ Live Reload combines the power of established hotpatching and hotswapping techno
 ** <<setup-live-reload-jrebel#, JRebel>>
 ** <<setup-live-reload-hotswap-agent#, HotswapAgent class and resource redefinition>>
 
-Each technology supported by Live Reload is meant to be run solely. Any overlap or simultaneous use of different hotpatching technologies might cause Live Reload to misbehave.
+[NOTE]
+Each technology supported by Live Reload is meant to be run exclusively. Any overlap or simultaneous use of different hotpatching technologies might cause Live Reload to misbehave.
 
 ==== Live Reload Limitations
 
@@ -35,7 +36,7 @@ We cover the general limitations here; the specific limitations are covered in t
 
 
 === Hotswapping specifics when using it in different Vaadin technology stacks
-Hotswapping provides a way to  load changed code into a running JVM and immediately see the effects of your changes without server restarts.
+Hotswapping provides a way to load changed code into a running JVM and immediately see the effects of your changes without server restarts.
 
 ** <<tutorial-plain-servlet-hotswap#, Hotswapping in Plain Servlet Applications>>
 ** <<tutorial-cdi-hotswap#,Hotswapping in CDI Applications>>


### PR DESCRIPTION
Fixes vaadin/flow#8020

Change docs to clear out difference between Live Reload and Hotswapping techniques.
Clarify that technologies are not meant to be ran at the same time
Instruct users to not use automatic reload browser extensions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-and-components-documentation/1257)
<!-- Reviewable:end -->
