### PR TITLE
Added example for injection of VaadinServiceEnabled Beans

### DIFF
--- a/documentation/cdi/tutorial-cdi-service-beans.asciidoc
+++ b/documentation/cdi/tutorial-cdi-service-beans.asciidoc
@@ -16,6 +16,8 @@ The https://vaadin.com/directory/component/vaadin-cdi/[Vaadin CDI] add-on refere
 * `ErrorHandler`.
 
 To ensure that the beans are recognized, they should be qualified by the `@VaadinServiceEnabled` annotation.
+This is required because this marks the bean which is used as I18N provider by the service. 
+If there are any other I18N beans, always the one, which is also used by the service is used.
 
 *Example*: Using the `@VaadinServiceEnabled` annotation to qualify `TestSystemMessagesProvider`.
 

--- a/documentation/cdi/tutorial-cdi-service-beans.asciidoc
+++ b/documentation/cdi/tutorial-cdi-service-beans.asciidoc
@@ -36,5 +36,14 @@ public class TestSystemMessagesProvider
         return messages;
     }
 }
+
+@Route
+public class SampleView extends Div {
+
+    @VaadinServiceEnabled
+    @Inject
+    private TestSystemMessagesProvider messageProvider;
+
+}
 ----
 * The purpose of the `@VaadinServiceScoped` context is to define a context with the lifespan of the Vaadin service. It is not mandatory for this kind of bean, but is recommended because other Vaadin contexts can be problematic. For example there is no guarantee that an active Vaadin session or UI context exists when the add-on looks up any of these beans. It is safe to use standard CDI `@Dependent` and `@ApplicationScoped` contexts.


### PR DESCRIPTION
It is not clear that the VaadinServiceEnabled annotation also needs to be used at injection.
Added an example to clarify that.

Might even be better to clarify why there is the additional VaadinServiceEnabled annotation and why VaadinServiceScoped doesn't suffice.