### PR TITLE
chore: switch master using V17 SNAPSHOTs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <flow.version>3.2-SNAPSHOT</flow.version>
-        <vaadin.version>16.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>17.0-SNAPSHOT</vaadin.version>
         <vaadin-portlet.version>1.0-SNAPSHOT</vaadin-portlet.version>
         <portlet-api.version>3.0.0</portlet-api.version>
         <jackson.version>2.9.7</jackson.version>


### PR DESCRIPTION
`master` was inconsistently using V16 SNAPSHOTs of the Vaadin platform. It should be using V17 snapshots because the `master` branch of this repo contains the docs for Vaadin 17.