### PR TITLE
fix: minor improvements to client-side binder docs

### DIFF
--- a/documentation/client-side-forms/tutorial-binder.asciidoc
+++ b/documentation/client-side-forms/tutorial-binder.asciidoc
@@ -77,7 +77,7 @@ class PersonForm extends LitElement {
 +
 The [classname]#PersonModel# here is generated alongside with a [classname]#Person# TypeScript data interface from the `Person.java` bean. It describes the structure of the data and the validation-related metadata for the client-side form binding.
 
-. Bind the UI components in the template using the `...="${field()}"` syntax:
+. Bind the UI components in the template using the `+...="${field()}"+` syntax:
 +
 [source, typescript]
 ----

--- a/documentation/client-side-forms/tutorial-form-status-tracking.asciidoc
+++ b/documentation/client-side-forms/tutorial-form-status-tracking.asciidoc
@@ -19,9 +19,9 @@ Some statuses are only available in `Binder` for the whole form but not a specif
 
 You can bind these statuses to some UI components so that the form's UI can be updated automatically when the form status changes, e.g., disable the reset button when the form is not dirty. 
 
-[source, HTML]
+[source, html]
 ----
-<vaadin-button ?disabled="${!this.binder.dirty}"
+<vaadin-button ?disabled="${!this.binder.dirty}">
   Reset
 </vaadin-button>
 ----

--- a/documentation/src/main/html/clientsideforms/tutorial-form-status-tracking.html
+++ b/documentation/src/main/html/clientsideforms/tutorial-form-status-tracking.html
@@ -1,0 +1,5 @@
+tutorial::client-side-forms/tutorial-form-status-tracking.asciidoc
+
+<vaadin-button ?disabled="${!this.binder.dirty}">
+    Reset
+</vaadin-button>


### PR DESCRIPTION
* fix: make the `...` syntax copy/paste-able
  - Prevent Asciidoctor from replacing tree dots (`...`) with an single ellipsis symbol (`…`).
  - In this case the rendered content should remain as three dots so that the code line could be easily copied / pasted 'as is'. By default AsciiDoc always does this replacement (see https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#text-replacement), and there is no global setting to turn it off. However, there is a workaround that can be used to disable replacement case by case: asciidoctor/asciidoctor#1060.
* fix: add missing closing `>` into code snippet