### PR TITLE
chore: add missing deps to fix build errors

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -49,6 +49,18 @@
             <artifactId>vaadin-spring</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-polymer-template</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-lit-template</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+
         <!-- needed for spring security docs validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Add `flow-polymer-template` and `flow-lit-template` dependencies to fix the compile errors during the build.