### PR TITLE
feat: Document LitTemplate disabled annotation support

### DIFF
--- a/documentation/components/tutorial-enabled-state.asciidoc
+++ b/documentation/components/tutorial-enabled-state.asciidoc
@@ -54,6 +54,10 @@ As a consequence, disabling a mapped component does not disable other mapped com
 whose elements are children of the disabled component's element in the template.
 See <<../polymer-templates/tutorial-template-mapped-components-limitations#, Mapped Components Limitations>> for details.
 
+[NOTE]
+LitTemplate doesn't support `disabled` attribute on `@Id` mapped components.
+See <<../polymer-templates/tutorial-template-mapped-components-limitations#, Mapped Components Limitations>> for details.
+
 == Implicitly Enabled and Disabled Components
 
 When an implicitly disabled component is detached from a disabled container, it is automatically enabled again. Similarly, if an enabled component is attached to a disabled container, it is automatically implicitly disabled.

--- a/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
+++ b/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
@@ -144,11 +144,13 @@ public class MainLayout extends LitTemplate {
 
 This will throw an `IllegalAttributeException` with the message
 ```
-Lit template 'com.example.MainLayout' injected element(s):
- * Element 'vaadin-button' with id 'button'
-uses the disabled attribute.
+Lit template 'com.example.MainLayout' injected element 'vaadin-button' with id 'button' uses the disabled attribute.
 Mapped components should instead be disabled using the 'setEnabled(false)' method on the server side.
 ```
+
+[NOTE]
+PolymerTemplate will not throw for using the `disabled` attribute, but only store it as a property for the element
+leaving the element as enabled on the server side.
 
 == Removing Mapped Elements
 

--- a/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
+++ b/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
@@ -108,6 +108,47 @@ class MainLayout extends LitElement {
 customElements.define("main-layout", MainLayout);
 ----
 
+== Template `disabled` attribute
+
+LitTemplate doesn't support using the `disabled` attribute for an id-mapped component.
+Id-mapped components should always be disabled from the server side using the `setEnabled(false)` method.
+
+*Faulty sample*
+
+[source,js]
+----
+class MainLayout extends LitElement {
+  render() {
+    return html`
+        <div>
+          <vaadin-button id="button" disabled></vaadin-button>
+        </div>
+      `;
+  }
+}
+
+customElements.define("main-layout", MainLayout);
+----
+
+[source,java]
+----
+@Tag("main-layout")
+@JsModule("./com/example/main-layout.js")
+public class MainLayout extends LitTemplate {
+
+    @Id("button")
+    private Button button;
+}
+----
+
+This will throw a `IllegalArgumentException` with the message
+```
+Lit template 'com.example.MainLayout' injected element(s):
+ * Element 'vaadin-button' with id 'button'
+uses the disabled attribute.
+Mapped components should instead be disabled using the 'setEnabled(false)' method on the server side.
+```
+
 == Removing Mapped Elements
 
 A virtually-mapped `Element` is connected to the `ShadowRoot` of the

--- a/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
+++ b/documentation/polymer-templates/tutorial-template-mapped-components-limitations.asciidoc
@@ -110,7 +110,8 @@ customElements.define("main-layout", MainLayout);
 
 == Template `disabled` attribute
 
-LitTemplate doesn't support using the `disabled` attribute for an id-mapped component.
+LitTemplate doesn't support using the `disabled` attribute for an id-mapped component and will
+throw an `IllegalAttributeException` with information on where it is used.
 Id-mapped components should always be disabled from the server side using the `setEnabled(false)` method.
 
 *Faulty sample*
@@ -141,7 +142,7 @@ public class MainLayout extends LitTemplate {
 }
 ----
 
-This will throw a `IllegalArgumentException` with the message
+This will throw an `IllegalAttributeException` with the message
 ```
 Lit template 'com.example.MainLayout' injected element(s):
  * Element 'vaadin-button' with id 'button'


### PR DESCRIPTION
Document limitation in LitTemplate not supporting
the disabled attribute for a id-mapped component.

part of vaadin/flow#9152