### PR TITLE
Fix cross reference

### DIFF
--- a/documentation-themes/styling-applications.asciidoc
+++ b/documentation-themes/styling-applications.asciidoc
@@ -64,7 +64,7 @@ If you wish to author your client-side views using some other technology (for ex
 Static images, which need to be accessible by the browser, should be placed in the [filename]#/src/main/webapp/# folder.
 For _Spring Boot -based projects_ use [filename]#/src/main/resources/META-INF/resources/#.
 
-See <<../importing-dependencies/tutorial-ways-of-importing#,Storing and Loading Resources>> for more information about how static resources are handled.
+See <<../flow/importing-dependencies/tutorial-ways-of-importing#,Storing and Loading Resources>> for more information about how static resources are handled.
 
 [.example]
 --


### PR DESCRIPTION
From “Themes / Styling Applications / Using Images” to “Framework / Storing and Loading Resources"